### PR TITLE
allow for command arguments in popen.

### DIFF
--- a/iolib.go
+++ b/iolib.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 	"unsafe"
 )
@@ -72,7 +73,8 @@ func newFile(L *LState, file *os.File, path string, flag int, perm os.FileMode, 
 
 func newProcess(L *LState, cmd string, writable, readable bool) (*LUserData, error) {
 	ud := L.NewUserData()
-	pp := exec.Command(cmd)
+	args := strings.Fields(cmd)
+	pp := exec.Command(args[0], args[1:]...)
 	lfile := &lFile{fp: nil, pp: pp, writer: nil, reader: nil, closed: false}
 	ud.Value = lfile
 


### PR DESCRIPTION
Previously limited Command to bins without flags and arguments.
This led to some (unintented?) behaviour.

This patch allows for simple commands, such as specifying a bin with additional flags, e.g. tail -f FILE.

While this patch isn't complete (e.g. using pipes), it is flexible enough (i.e. bash -c '').
If the command is more complex than that, it should merit a shellscript.