### PR TITLE
fix table not deleting dict values

### DIFF
--- a/table.go
+++ b/table.go
@@ -117,12 +117,12 @@ func (tb *LTable) RawSet(key LValue, value LValue) {
 			return
 		}
 	}
-	tb.dict[key] = value
+	tb.RawSetH(key, value)
 }
 
 func (tb *LTable) RawSetInt(key int, value LValue) {
 	if key < 1 || key >= MaxArrayIndex {
-		tb.dict[LNumber(key)] = value
+		tb.RawSetH(LNumber(key), value)
 		return
 	}
 	index := key - 1
@@ -141,7 +141,11 @@ func (tb *LTable) RawSetInt(key int, value LValue) {
 }
 
 func (tb *LTable) RawSetH(key LValue, value LValue) {
-	tb.dict[key] = value
+	if value == LNil {
+		delete(tb.dict, key)
+	} else {
+		tb.dict[key] = value
+	}
 }
 
 func (tb *LTable) RawGet(key LValue) LValue {


### PR DESCRIPTION
When LNil is used as the value in a table assignment, it should delete the key, rather than storing it in the table. Doing the latter can cause huge amounts of memory to be wasted.

You can see this for yourself by viewing the memory usage of `glua` running the following script, before and after applying the patch:

```lua
local tbl = {}
for i = 1, 100000000 do
  tbl[tostring(i)] = nil
end
```