### PR TITLE
Add gluahttp to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -703,6 +703,7 @@ Libraries for GopherLua
 
 - `gopher-luar <https://github.com/layeh/gopher-luar>`_ : Custom type reflection for gopher-lua
 - `gluamapper <https://github.com/yuin/gluamapper>`_ : Mapping a Lua table to a Go struct
+- `gluahttp <https://github.com/cjoudrey/gluahttp>`_ : HTTP request module for gopher-lua
 
 ----------------------------------------------------------------
 License


### PR DESCRIPTION
@yuin I'm not sure if you are listing all gopher-lua modules in the README. If so, here's an HTTP request module that I am working on.