### PR TITLE
Adding DoReader helper function

### DIFF
--- a/auxlib.go
+++ b/auxlib.go
@@ -380,6 +380,17 @@ func (ls *LState) DoString(source string) error {
 	}
 }
 
+//DoReader executes lua code read from reader.
+//Name is a symbolic name to display in error messages.
+func (ls *LState) DoReader(reader io.Reader, name string) error {
+	if fn, err := ls.Load(reader, name); err != nil {
+		return err
+	} else {
+		ls.Push(fn)
+		return ls.PCall(0, MultRet, nil)
+	}
+}
+
 func (ls *LState) OpenLibs() {
 	// loadlib must be loaded 1st
 	loadOpen(ls)

--- a/auxlib_test.go
+++ b/auxlib_test.go
@@ -1,6 +1,7 @@
 package lua
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -291,4 +292,15 @@ func TestOptChannel(t *testing.T) {
 		L.OptChannel(3, defch)
 		return 0
 	}, "channel expected, got string")
+}
+
+func TestDoReader(t *testing.T) {
+	L := NewState()
+	defer L.Close()
+
+	err := L.DoReader(strings.NewReader("a=1"), "<reader>")
+	if err != nil {
+		t.Errorf("Error executing lua through DoReader: %v", err)
+		return
+	}
 }

--- a/auxlib_test.go
+++ b/auxlib_test.go
@@ -303,4 +303,10 @@ func TestDoReader(t *testing.T) {
 		t.Errorf("Error executing lua through DoReader: %v", err)
 		return
 	}
+
+	err = L.DoReader(strings.NewReader("bogus"), "<reader>")
+	if err == nil {
+		t.Errorf("No error generated when executing bogus code")
+		return
+	}
 }


### PR DESCRIPTION
DoReader functions the same way as DoFile/DoString, except the
program is read in from a reader.  This is a trivial change since
Load* already reads in from a reader.