### PR TITLE
Allow for optional disabling of library opening and stdin/stdout control

### DIFF
--- a/state.go
+++ b/state.go
@@ -89,6 +89,9 @@ type Options struct {
 	CallStackSize int
 	// Data stack size. This defaults to `lua.RegistrySize`.
 	RegistrySize int
+
+	// Controls whether or not libraries are opened by default
+	SkipOpenLibs bool
 }
 
 /* }}} */
@@ -926,6 +929,7 @@ func NewState(opts ...Options) *LState {
 			CallStackSize: CallStackSize,
 			RegistrySize:  RegistrySize,
 		})
+		ls.OpenLibs()
 	} else {
 		if opts[0].CallStackSize < 1 {
 			opts[0].CallStackSize = CallStackSize
@@ -934,8 +938,10 @@ func NewState(opts ...Options) *LState {
 			opts[0].RegistrySize = RegistrySize
 		}
 		ls = newLState(opts[0])
+		if !opts[0].SkipOpenLibs {
+			ls.OpenLibs()
+		}
 	}
-	ls.OpenLibs()
 	return ls
 }
 

--- a/state_test.go
+++ b/state_test.go
@@ -24,6 +24,16 @@ func TestCallStackOverflow(t *testing.T) {
     `, "stack overflow")
 }
 
+func TestSkipOpenLibs(t *testing.T) {
+	L := NewState(Options{SkipOpenLibs: true})
+	defer L.Close()
+	errorIfScriptNotFail(t, L, `print("")`,
+		"attempt to call a non-function object")
+	L2 := NewState()
+	defer L2.Close()
+	errorIfScriptFail(t, L2, `print("")`)
+}
+
 func TestGetAndReplace(t *testing.T) {
 	L := NewState()
 	defer L.Close()


### PR DESCRIPTION
These two changes are to make https://github.com/jtolds/go-manhole work.

I'd be okay if we just merged the second change (the optional skipping of library opening), as it makes the first change (control of stdout/stdin/stderr) unnecessary for my purposes.

Thanks!