### PR TITLE
Support shebang

### DIFF
--- a/auxlib.go
+++ b/auxlib.go
@@ -356,11 +356,14 @@ func (ls *LState) LoadFile(path string) (*LFunction, error) {
 
 	reader := bufio.NewReader(file)
 	// get the first character.
-	c, _ := reader.ReadByte()
+	c, err := reader.ReadByte()
+	if err != nil {
+		return nil, newApiErrorE(ApiErrorFile, err)
+	}
 	if c == byte('#') {
 		// Unix exec. file?
 		// skip first line
-		_, _, err = reader.ReadLine()
+		_, err, _ = readBufioLine(reader)
 		if err != nil {
 			return nil, newApiErrorE(ApiErrorFile, err)
 		}

--- a/auxlib_test.go
+++ b/auxlib_test.go
@@ -1,6 +1,8 @@
 package lua
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 )
 
@@ -291,4 +293,25 @@ func TestOptChannel(t *testing.T) {
 		L.OptChannel(3, defch)
 		return 0
 	}, "channel expected, got string")
+}
+
+func TestLoadFileForShebang(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "")
+	errorIfNotNil(t, err)
+
+	err = ioutil.WriteFile(tmpFile.Name(), []byte(`#!/path/to/lua
+print("hello")
+`), 0644)
+	errorIfNotNil(t, err)
+
+	defer func() {
+		tmpFile.Close()
+		os.Remove(tmpFile.Name())
+	}()
+
+	L := NewState()
+	defer L.Close()
+
+	_, err = L.LoadFile(tmpFile.Name())
+	errorIfNotNil(t, err)
 }


### PR DESCRIPTION
Fixes #72 .

Simply removes the first line before loading if the lua source code begin with '#'.
I modified gopher-lua code based on [lua5.1.3 luaL_loadfile code](https://github.com/lua/lua/blob/5.1.3/src/lauxlib.c#L567-L580).

