### PR TITLE
util: support os.date %x and %X fmt

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -100,7 +100,7 @@ func (fs *flagScanner) Next() (byte, bool) {
 var cDateFlagToGo = map[byte]string{
 	'a': "mon", 'A': "Monday", 'b': "Jan", 'B': "January", 'c': "02 Jan 06 15:04 MST", 'd': "02",
 	'F': "2006-01-02", 'H': "15", 'I': "03", 'm': "01", 'M': "04", 'p': "PM", 'P': "pm", 'S': "05",
-	'y': "06", 'Y': "2006", 'z': "-0700", 'Z': "MST"}
+	'x': "15/04/05", 'X': "15:04:05",'y': "06", 'Y': "2006", 'z': "-0700", 'Z': "MST"}
 
 func strftime(t time.Time, cfmt string) string {
 	sc := newFlagScanner('%', "", "", cfmt)


### PR DESCRIPTION
Fixes # let os.date support %x fmt

Changes proposed in this pull request:

- add %x and %X golang mapping into util.cDateFlagToGo
