### PR TITLE
Add an option to pass in a Context to cancel Lua scripts

### DIFF
--- a/_state.go
+++ b/_state.go
@@ -1,6 +1,7 @@
 package lua
 
 import (
+	"context"
 	"fmt"
 	"github.com/yuin/gopher-lua/parse"
 	"io"
@@ -93,6 +94,8 @@ type Options struct {
 	SkipOpenLibs bool
 	// Tells whether a Go stacktrace should be included in a Lua stacktrace when panics occur.
 	IncludeGoStackTrace bool
+	// A Context that can be used to stop the Lua VM.
+	Context context.Context
 }
 
 /* }}} */

--- a/_vm.go
+++ b/_vm.go
@@ -24,6 +24,14 @@ func mainLoop(L *LState, baseframe *callFrame) {
 		cf = L.currentFrame
 		inst = cf.Fn.Proto.Code[cf.Pc]
 		cf.Pc++
+		if L.Options.Context != nil {
+			select {
+			case <-L.Options.Context.Done():
+				L.RaiseError("Context done")
+				return
+			default:
+			}
+		}
 		if jumpTable[int(inst>>26)](L, inst, baseframe) == 1 {
 			return
 		}

--- a/state.go
+++ b/state.go
@@ -5,6 +5,7 @@ package lua
 ////////////////////////////////////////////////////////
 
 import (
+	"context"
 	"fmt"
 	"github.com/yuin/gopher-lua/parse"
 	"io"
@@ -97,6 +98,8 @@ type Options struct {
 	SkipOpenLibs bool
 	// Tells whether a Go stacktrace should be included in a Lua stacktrace when panics occur.
 	IncludeGoStackTrace bool
+	// A Context that can be used to stop the Lua VM.
+	Context context.Context
 }
 
 /* }}} */

--- a/vm.go
+++ b/vm.go
@@ -28,6 +28,14 @@ func mainLoop(L *LState, baseframe *callFrame) {
 		cf = L.currentFrame
 		inst = cf.Fn.Proto.Code[cf.Pc]
 		cf.Pc++
+		if L.Options.Context != nil {
+			select {
+			case <-L.Options.Context.Done():
+				L.RaiseError("Context done")
+				return
+			default:
+			}
+		}
 		if jumpTable[int(inst>>26)](L, inst, baseframe) == 1 {
 			return
 		}


### PR DESCRIPTION
This PR adds a `context.Context` to the options struct which allows easy cancellation of running scripts.

As context was only introduced in Go 1.7 this would mean dropping support for previous versions of Go.
