### PR TITLE
go: prune 'exported' fields and constants; improve readability

### DIFF
--- a/_state.go
+++ b/_state.go
@@ -116,16 +116,16 @@ type Debug struct {
 /* callFrame {{{ */
 
 type callFrame struct {
-	Idx        int
-	Fn         *LFunction
-	Parent     *callFrame
-	Pc         int
-	Base       int
-	LocalBase  int
-	ReturnBase int
-	NArgs      int
-	NRet       int
-	TailCall   int
+	idx        int
+	fn         *LFunction
+	parent     *callFrame
+	pc         int
+	base       int
+	localBase  int
+	returnBase int
+	nArgs      int
+	nRet       int
+	tailCall   int
 }
 
 type callFrameStack struct {
@@ -148,7 +148,7 @@ func (cs *callFrameStack) Clear() {
 
 func (cs *callFrameStack) Push(v callFrame) { // +inline-start
 	cs.array[cs.sp] = v
-	cs.array[cs.sp].Idx = cs.sp
+	cs.array[cs.sp].idx = cs.sp
 	cs.sp++
 } // +inline-end
 
@@ -164,11 +164,11 @@ func (cs *callFrameStack) Remove(sp int) {
 		next = &cs.array[nsp]
 	}
 	if next != nil {
-		next.Parent = pre
+		next.parent = pre
 	}
 	for i := sp; i+1 < cs.sp; i++ {
 		cs.array[i] = cs.array[i+1]
-		cs.array[i].Idx = i
+		cs.array[i].idx = i
 		cs.sp = i
 	}
 	cs.sp++
@@ -344,8 +344,8 @@ func (ls *LState) printReg() {
 	println("thread:", ls)
 	println("top:", ls.reg.Top())
 	if ls.currentFrame != nil {
-		println("function base:", ls.currentFrame.Base)
-		println("return base:", ls.currentFrame.ReturnBase)
+		println("function base:", ls.currentFrame.base)
+		println("return base:", ls.currentFrame.returnBase)
 	} else {
 		println("(vm not started)")
 	}
@@ -365,19 +365,19 @@ func (ls *LState) printCallStack() {
 		if frame == nil {
 			break
 		}
-		if frame.Fn.IsG {
-			println("IsG:", true, "Frame:", frame, "Fn:", frame.Fn)
+		if frame.fn.IsG {
+			println("IsG:", true, "Frame:", frame, "Fn:", frame.fn)
 		} else {
-			println("IsG:", false, "Frame:", frame, "Fn:", frame.Fn, "pc:", frame.Pc)
+			println("IsG:", false, "Frame:", frame, "Fn:", frame.fn, "pc:", frame.pc)
 		}
 	}
 	println("-------------------------")
 }
 
 func (ls *LState) closeAllUpvalues() { // +inline-start
-	for cf := ls.currentFrame; cf != nil; cf = cf.Parent {
-		if !cf.Fn.IsG {
-			ls.closeUpvalues(cf.LocalBase)
+	for cf := ls.currentFrame; cf != nil; cf = cf.parent {
+		if !cf.fn.IsG {
+			ls.closeUpvalues(cf.localBase)
 		}
 	}
 } // +inline-end
@@ -398,21 +398,21 @@ func (ls *LState) raiseError(level int, format string, args ...interface{}) {
 }
 
 func (ls *LState) findLocal(frame *callFrame, no int) string {
-	fn := frame.Fn
+	fn := frame.fn
 	if !fn.IsG {
-		if name, ok := fn.LocalName(no, frame.Pc-1); ok {
+		if name, ok := fn.LocalName(no, frame.pc-1); ok {
 			return name
 		}
 	}
 	var top int
 	if ls.currentFrame == frame {
 		top = ls.reg.Top()
-	} else if frame.Idx+1 < ls.stack.Sp() {
-		top = ls.stack.At(frame.Idx + 1).Base
+	} else if frame.idx+1 < ls.stack.Sp() {
+		top = ls.stack.At(frame.idx + 1).base
 	} else {
 		return ""
 	}
-	if top-frame.LocalBase >= no {
+	if top-frame.localBase >= no {
 		return "(*temporary)"
 	}
 	return ""
@@ -424,7 +424,7 @@ func (ls *LState) where(level int, skipg bool) string {
 		return ""
 	}
 	cf := dbg.frame
-	proto := cf.Fn.Proto
+	proto := cf.fn.Proto
 	sourcename := "[G]"
 	if proto != nil {
 		sourcename = proto.SourceName
@@ -433,7 +433,7 @@ func (ls *LState) where(level int, skipg bool) string {
 	}
 	line := ""
 	if proto != nil {
-		line = fmt.Sprintf("%v:", proto.DbgSourcePositions[cf.Pc-1])
+		line = fmt.Sprintf("%v:", proto.DbgSourcePositions[cf.pc-1])
 	}
 	return fmt.Sprintf("%v:%v", sourcename, line)
 }
@@ -446,8 +446,8 @@ func (ls *LState) stackTrace(level int) string {
 		for dbg, ok := ls.GetStack(i); ok; dbg, ok = ls.GetStack(i) {
 			cf := dbg.frame
 			buf = append(buf, fmt.Sprintf("\t%v in %v", ls.Where(i), ls.formattedFrameFuncName(cf)))
-			if !cf.Fn.IsG && cf.TailCall > 0 {
-				for tc := cf.TailCall; tc > 0; tc-- {
+			if !cf.fn.IsG && cf.tailCall > 0 {
+				for tc := cf.tailCall; tc > 0; tc-- {
 					buf = append(buf, "\t(tailcall): ?")
 					i++
 				}
@@ -484,7 +484,7 @@ func (ls *LState) rawFrameFuncName(fr *callFrame) string {
 }
 
 func (ls *LState) frameFuncName(fr *callFrame) (string, bool) {
-	frame := fr.Parent
+	frame := fr.parent
 	if frame == nil {
 		if ls.Parent == nil {
 			return "main chunk", true
@@ -492,20 +492,20 @@ func (ls *LState) frameFuncName(fr *callFrame) (string, bool) {
 			return "corountine", true
 		}
 	}
-	if !frame.Fn.IsG {
-		pc := frame.Pc - 1
-		for _, call := range frame.Fn.Proto.DbgCalls {
+	if !frame.fn.IsG {
+		pc := frame.pc - 1
+		for _, call := range frame.fn.Proto.DbgCalls {
 			if call.Pc == pc {
 				name := call.Name
-				if (name == "?" || fr.TailCall > 0) && !fr.Fn.IsG {
-					name = fmt.Sprintf("<%v:%v>", fr.Fn.Proto.SourceName, fr.Fn.Proto.LineDefined)
+				if (name == "?" || fr.tailCall > 0) && !fr.fn.IsG {
+					name = fmt.Sprintf("<%v:%v>", fr.fn.Proto.SourceName, fr.fn.Proto.LineDefined)
 				}
 				return name, false
 			}
 		}
 	}
-	if !fr.Fn.IsG {
-		return fmt.Sprintf("<%v:%v>", fr.Fn.Proto.SourceName, fr.Fn.Proto.LineDefined), false
+	if !fr.fn.IsG {
+		return fmt.Sprintf("<%v:%v>", fr.fn.Proto.SourceName, fr.fn.Proto.LineDefined), false
 	}
 	return "(anonymous)", false
 }
@@ -536,7 +536,7 @@ func (ls *LState) indexToReg(idx int) int {
 func (ls *LState) currentLocalBase() int {
 	base := 0
 	if ls.currentFrame != nil {
-		base = ls.currentFrame.LocalBase
+		base = ls.currentFrame.localBase
 	}
 	return base
 }
@@ -547,28 +547,28 @@ func (ls *LState) currentEnv() *LTable {
 		if ls.currentFrame == nil {
 			return ls.Env
 		}
-		return ls.currentFrame.Fn.Env
+		return ls.currentFrame.fn.Env
 	*/
 }
 
 func (ls *LState) rkValue(idx int) LValue {
 	/*
 		if OpIsK(idx) {
-			return ls.currentFrame.Fn.Proto.Constants[opIndexK(idx)]
+			return ls.currentFrame.fn.Proto.Constants[opIndexK(idx)]
 		}
-		return ls.reg.Get(ls.currentFrame.LocalBase + idx)
+		return ls.reg.Get(ls.currentFrame.localBase + idx)
 	*/
 	if (idx & opBitRk) != 0 {
-		return ls.currentFrame.Fn.Proto.Constants[idx & ^opBitRk]
+		return ls.currentFrame.fn.Proto.Constants[idx & ^opBitRk]
 	}
-	return ls.reg.array[ls.currentFrame.LocalBase+idx]
+	return ls.reg.array[ls.currentFrame.localBase+idx]
 }
 
 func (ls *LState) rkString(idx int) string {
 	if (idx & opBitRk) != 0 {
-		return ls.currentFrame.Fn.Proto.stringConstants[idx & ^opBitRk]
+		return ls.currentFrame.fn.Proto.stringConstants[idx & ^opBitRk]
 	}
-	return string(ls.reg.array[ls.currentFrame.LocalBase+idx].(LString))
+	return string(ls.reg.array[ls.currentFrame.localBase+idx].(LString))
 }
 
 func (ls *LState) closeUpvalues(idx int) { // +inline-start
@@ -677,14 +677,14 @@ func (ls *LState) metaCall(lvalue LValue) (*LFunction, bool) {
 }
 
 func (ls *LState) initCallFrame(cf *callFrame) { // +inline-start
-	if cf.Fn.IsG {
-		ls.reg.SetTop(cf.LocalBase + cf.NArgs)
+	if cf.fn.IsG {
+		ls.reg.SetTop(cf.localBase + cf.nArgs)
 	} else {
-		proto := cf.Fn.Proto
-		nargs := cf.NArgs
+		proto := cf.fn.Proto
+		nargs := cf.nArgs
 		np := int(proto.NumParameters)
 		for i := nargs; i < np; i++ {
-			ls.reg.array[cf.LocalBase+i] = LNil
+			ls.reg.array[cf.localBase+i] = LNil
 			nargs = np
 		}
 
@@ -693,9 +693,9 @@ func (ls *LState) initCallFrame(cf *callFrame) { // +inline-start
 				nargs = int(proto.NumUsedRegisters)
 			}
 			for i := np; i < nargs; i++ {
-				ls.reg.array[cf.LocalBase+i] = LNil
+				ls.reg.array[cf.localBase+i] = LNil
 			}
-			ls.reg.top = cf.LocalBase + int(proto.NumUsedRegisters)
+			ls.reg.top = cf.localBase + int(proto.NumUsedRegisters)
 		} else {
 			/* swap vararg positions:
 					   closure
@@ -719,30 +719,30 @@ func (ls *LState) initCallFrame(cf *callFrame) { // +inline-start
 				nvarargs = 0
 			}
 
-			ls.reg.SetTop(cf.LocalBase + nargs + np)
+			ls.reg.SetTop(cf.localBase + nargs + np)
 			for i := 0; i < np; i++ {
-				//ls.reg.Set(cf.LocalBase+nargs+i, ls.reg.Get(cf.LocalBase+i))
-				ls.reg.array[cf.LocalBase+nargs+i] = ls.reg.array[cf.LocalBase+i]
-				//ls.reg.Set(cf.LocalBase+i, LNil)
-				ls.reg.array[cf.LocalBase+i] = LNil
+				//ls.reg.Set(cf.localBase+nargs+i, ls.reg.Get(cf.localBase+i))
+				ls.reg.array[cf.localBase+nargs+i] = ls.reg.array[cf.localBase+i]
+				//ls.reg.Set(cf.localBase+i, LNil)
+				ls.reg.array[cf.localBase+i] = LNil
 			}
 
 			if CompatVarArg {
-				ls.reg.SetTop(cf.LocalBase + nargs + np + 1)
+				ls.reg.SetTop(cf.localBase + nargs + np + 1)
 				if (proto.IsVarArg & VarArgNeedsArg) != 0 {
 					argtb := newLTable(nvarargs, 0)
 					for i := 0; i < nvarargs; i++ {
-						argtb.RawSetInt(i+1, ls.reg.Get(cf.LocalBase+np+i))
+						argtb.RawSetInt(i+1, ls.reg.Get(cf.localBase+np+i))
 					}
 					argtb.RawSetString("n", LNumber(nvarargs))
-					//ls.reg.Set(cf.LocalBase+nargs+np, argtb)
-					ls.reg.array[cf.LocalBase+nargs+np] = argtb
+					//ls.reg.Set(cf.localBase+nargs+np, argtb)
+					ls.reg.array[cf.localBase+nargs+np] = argtb
 				} else {
-					ls.reg.array[cf.LocalBase+nargs+np] = LNil
+					ls.reg.array[cf.localBase+nargs+np] = LNil
 				}
 			}
-			cf.LocalBase += nargs
-			maxreg := cf.LocalBase + int(proto.NumUsedRegisters)
+			cf.localBase += nargs
+			maxreg := cf.localBase + int(proto.NumUsedRegisters)
 			ls.reg.SetTop(maxreg)
 		}
 	}
@@ -750,10 +750,10 @@ func (ls *LState) initCallFrame(cf *callFrame) { // +inline-start
 
 func (ls *LState) pushCallFrame(cf callFrame, fn LValue, meta bool) { // +inline-start
 	if meta {
-		cf.NArgs++
-		ls.reg.Insert(fn, cf.LocalBase)
+		cf.nArgs++
+		ls.reg.Insert(fn, cf.localBase)
 	}
-	if cf.Fn == nil {
+	if cf.fn == nil {
 		ls.RaiseError("attempt to call a non-function object")
 	}
 	if ls.stack.sp == ls.Options.CallStackSize {
@@ -773,15 +773,15 @@ func (ls *LState) callR(nargs, nret, rbase int) {
 	lv := ls.reg.Get(base)
 	fn, meta := ls.metaCall(lv)
 	ls.pushCallFrame(callFrame{
-		Fn:         fn,
-		Pc:         0,
-		Base:       base,
-		LocalBase:  base + 1,
-		ReturnBase: rbase,
-		NArgs:      nargs,
-		NRet:       nret,
-		Parent:     ls.currentFrame,
-		TailCall:   0,
+		fn:         fn,
+		pc:         0,
+		base:       base,
+		localBase:  base + 1,
+		returnBase: rbase,
+		nArgs:      nargs,
+		nRet:       nret,
+		parent:     ls.currentFrame,
+		tailCall:   0,
 	}, lv, meta)
 	if ls.G.MainThread == nil {
 		ls.G.MainThread = ls
@@ -998,7 +998,7 @@ func (ls *LState) Replace(idx int, value LValue) {
 				ls.RaiseError("no calling environment")
 			}
 			if tb, ok := value.(*LTable); ok {
-				ls.currentFrame.Fn.Env = tb
+				ls.currentFrame.fn.Env = tb
 			} else {
 				ls.RaiseError("environment must be a table(%v)", value.Type().String())
 			}
@@ -1009,7 +1009,7 @@ func (ls *LState) Replace(idx int, value LValue) {
 				ls.RaiseError("_G must be a table(%v)", value.Type().String())
 			}
 		default:
-			fn := ls.currentFrame.Fn
+			fn := ls.currentFrame.fn
 			index := GlobalsIndex - idx - 1
 			if index < len(fn.Upvalues) {
 				fn.Upvalues[index].SetValue(value)
@@ -1042,11 +1042,11 @@ func (ls *LState) Get(idx int) LValue {
 			if ls.currentFrame == nil {
 				return ls.Env
 			}
-			return ls.currentFrame.Fn.Env
+			return ls.currentFrame.fn.Env
 		case GlobalsIndex:
 			return ls.G.Global
 		default:
-			fn := ls.currentFrame.Fn
+			fn := ls.currentFrame.fn
 			index := GlobalsIndex - idx - 1
 			if index < len(fn.Upvalues) {
 				return fn.Upvalues[index].Value()
@@ -1245,7 +1245,7 @@ func (ls *LState) Error(lv LValue, level int) {
 
 func (ls *LState) GetInfo(what string, dbg *Debug, fn LValue) (LValue, error) {
 	if !strings.HasPrefix(what, ">") {
-		fn = dbg.frame.Fn
+		fn = dbg.frame.fn
 	} else {
 		what = what[1:]
 	}
@@ -1260,11 +1260,11 @@ func (ls *LState) GetInfo(what string, dbg *Debug, fn LValue) (LValue, error) {
 		case 'f':
 			retfn = true
 		case 'S':
-			if dbg.frame != nil && dbg.frame.Parent == nil {
+			if dbg.frame != nil && dbg.frame.parent == nil {
 				dbg.What = "main"
 			} else if f.IsG {
 				dbg.What = "G"
-			} else if dbg.frame != nil && dbg.frame.TailCall > 0 {
+			} else if dbg.frame != nil && dbg.frame.tailCall > 0 {
 				dbg.What = "tail"
 			} else {
 				dbg.What = "Lua"
@@ -1276,8 +1276,8 @@ func (ls *LState) GetInfo(what string, dbg *Debug, fn LValue) (LValue, error) {
 			}
 		case 'l':
 			if !f.IsG && dbg.frame != nil {
-				if dbg.frame.Pc > 0 {
-					dbg.CurrentLine = f.Proto.DbgSourcePositions[dbg.frame.Pc-1]
+				if dbg.frame.pc > 0 {
+					dbg.CurrentLine = f.Proto.DbgSourcePositions[dbg.frame.pc-1]
 				}
 			} else {
 				dbg.CurrentLine = -1
@@ -1302,10 +1302,10 @@ func (ls *LState) GetInfo(what string, dbg *Debug, fn LValue) (LValue, error) {
 
 func (ls *LState) GetStack(level int) (*Debug, bool) {
 	frame := ls.currentFrame
-	for ; level > 0 && frame != nil; frame = frame.Parent {
+	for ; level > 0 && frame != nil; frame = frame.parent {
 		level--
-		if !frame.Fn.IsG {
-			level -= frame.TailCall
+		if !frame.fn.IsG {
+			level -= frame.tailCall
 		}
 	}
 
@@ -1320,7 +1320,7 @@ func (ls *LState) GetStack(level int) (*Debug, bool) {
 func (ls *LState) GetLocal(dbg *Debug, no int) (string, LValue) {
 	frame := dbg.frame
 	if name := ls.findLocal(frame, no); len(name) > 0 {
-		return name, ls.reg.Get(frame.LocalBase + no - 1)
+		return name, ls.reg.Get(frame.localBase + no - 1)
 	}
 	return "", LNil
 }
@@ -1328,7 +1328,7 @@ func (ls *LState) GetLocal(dbg *Debug, no int) (string, LValue) {
 func (ls *LState) SetLocal(dbg *Debug, no int, lv LValue) string {
 	frame := dbg.frame
 	if name := ls.findLocal(frame, no); len(name) > 0 {
-		ls.reg.Set(frame.LocalBase+no-1, lv)
+		ls.reg.Set(frame.localBase+no-1, lv)
 		return name
 	}
 	return ""
@@ -1654,15 +1654,15 @@ func (ls *LState) Resume(th *LState, fn *LFunction, args ...LValue) (ResumeState
 	if !isstarted {
 		base := 0
 		th.stack.Push(callFrame{
-			Fn:         fn,
-			Pc:         0,
-			Base:       base,
-			LocalBase:  base + 1,
-			ReturnBase: base,
-			NArgs:      0,
-			NRet:       MultRet,
-			Parent:     nil,
-			TailCall:   0,
+			fn:         fn,
+			pc:         0,
+			base:       base,
+			localBase:  base + 1,
+			returnBase: base,
+			nArgs:      0,
+			nRet:       MultRet,
+			parent:     nil,
+			tailCall:   0,
 		})
 	}
 
@@ -1681,7 +1681,7 @@ func (ls *LState) Resume(th *LState, fn *LFunction, args ...LValue) (ResumeState
 		for _, arg := range args {
 			th.Push(arg)
 		}
-		cf.NArgs = len(args)
+		cf.nArgs = len(args)
 		th.initCallFrame(cf)
 		th.Panic = panicWithoutTraceback
 	} else {

--- a/_vm.go
+++ b/_vm.go
@@ -157,7 +157,7 @@ var jumpTable [opCodeMax + 1]instFunc
 
 func init() {
 	jumpTable = [opCodeMax + 1]instFunc{
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_MOVE
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_MOVE
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -167,7 +167,7 @@ func init() {
 			reg.Set(RA, reg.Get(lbase+B))
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_MOVEN
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_MOVEN
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -187,7 +187,7 @@ func init() {
 			cf.Pc = pc
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_LOADK
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_LOADK
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -197,7 +197,7 @@ func init() {
 			reg.Set(RA, cf.Fn.Proto.Constants[Bx])
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_LOADBOOL
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_LOADBOOL
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -215,7 +215,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_LOADNIL
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_LOADNIL
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -227,7 +227,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_GETUPVAL
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_GETUPVAL
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -237,7 +237,7 @@ func init() {
 			reg.Set(RA, cf.Fn.Upvalues[B].Value())
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_GETGLOBAL
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_GETGLOBAL
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -248,7 +248,7 @@ func init() {
 			reg.Set(RA, L.getFieldString(cf.Fn.Env, cf.Fn.Proto.stringConstants[Bx]))
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_GETTABLE
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_GETTABLE
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -259,7 +259,7 @@ func init() {
 			reg.Set(RA, L.getField(reg.Get(lbase+B), L.rkValue(C)))
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_GETTABLEKS
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_GETTABLEKS
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -270,7 +270,7 @@ func init() {
 			reg.Set(RA, L.getFieldString(reg.Get(lbase+B), L.rkString(C)))
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_SETGLOBAL
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_SETGLOBAL
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -281,7 +281,7 @@ func init() {
 			L.setFieldString(cf.Fn.Env, cf.Fn.Proto.stringConstants[Bx], reg.Get(RA))
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_SETUPVAL
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_SETUPVAL
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -291,7 +291,7 @@ func init() {
 			cf.Fn.Upvalues[B].SetValue(reg.Get(RA))
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_SETTABLE
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_SETTABLE
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -302,7 +302,7 @@ func init() {
 			L.setField(reg.Get(RA), L.rkValue(B), L.rkValue(C))
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_SETTABLEKS
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_SETTABLEKS
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -313,7 +313,7 @@ func init() {
 			L.setFieldString(reg.Get(RA), L.rkString(B), L.rkValue(C))
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_NEWTABLE
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_NEWTABLE
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -324,7 +324,7 @@ func init() {
 			reg.Set(RA, newLTable(B, C))
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_SELF
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_SELF
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -337,13 +337,13 @@ func init() {
 			reg.Set(RA+1, selfobj)
 			return 0
 		},
-		opArith, // OP_ADD
-		opArith, // OP_SUB
-		opArith, // OP_MUL
-		opArith, // OP_DIV
-		opArith, // OP_MOD
-		opArith, // OP_POW
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_UNM
+		opArith, // op_ADD
+		opArith, // op_SUB
+		opArith, // op_MUL
+		opArith, // op_DIV
+		opArith, // op_MOD
+		opArith, // op_POW
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_UNM
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -372,7 +372,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_NOT
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_NOT
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -386,7 +386,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_LEN
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_LEN
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -411,7 +411,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_CONCAT
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_CONCAT
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -424,13 +424,13 @@ func init() {
 			reg.Set(RA, stringConcat(L, RC-RB+1, RC))
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_JMP
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_JMP
 			cf := L.currentFrame
 			Sbx := int(inst&0x3ffff) - opMaxArgSbx //GETSBX
 			cf.Pc += Sbx
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_EQ
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_EQ
 			cf := L.currentFrame
 			A := int(inst>>18) & 0xff //GETA
 			B := int(inst & 0x1ff)    //GETB
@@ -445,7 +445,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_LT
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_LT
 			cf := L.currentFrame
 			A := int(inst>>18) & 0xff //GETA
 			B := int(inst & 0x1ff)    //GETB
@@ -460,7 +460,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_LE
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_LE
 			cf := L.currentFrame
 			A := int(inst>>18) & 0xff //GETA
 			B := int(inst & 0x1ff)    //GETB
@@ -503,7 +503,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_TEST
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_TEST
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -515,7 +515,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_TESTSET
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_TESTSET
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -530,7 +530,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_CALL
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_CALL
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -558,7 +558,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_TAILCALL
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_TAILCALL
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -623,7 +623,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_RETURN
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_RETURN
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -653,7 +653,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_FORLOOP
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_FORLOOP
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -682,7 +682,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_FORPREP
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_FORPREP
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -701,7 +701,7 @@ func init() {
 			cf.Pc += Sbx
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_TFORLOOP
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_TFORLOOP
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -722,7 +722,7 @@ func init() {
 			cf.Pc++
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_SETLIST
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_SETLIST
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -745,7 +745,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_CLOSE
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_CLOSE
 			cf := L.currentFrame
 			lbase := cf.LocalBase
 			A := int(inst>>18) & 0xff //GETA
@@ -753,7 +753,7 @@ func init() {
 			// +inline-call L.closeUpvalues RA
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_CLOSURE
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_CLOSURE
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -768,15 +768,15 @@ func init() {
 				cf.Pc++
 				B := opGetArgB(inst)
 				switch opGetOpCode(inst) {
-				case OP_MOVE:
+				case op_MOVE:
 					closure.Upvalues[i] = L.findUpvalue(lbase + B)
-				case OP_GETUPVAL:
+				case op_GETUPVAL:
 					closure.Upvalues[i] = cf.Fn.Upvalues[B]
 				}
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_VARARG
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_VARARG
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -795,13 +795,13 @@ func init() {
 			// +inline-call reg.CopyRange RA cf.Base+nparams+1 cf.LocalBase nwant
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_NOP
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_NOP
 			return 0
 		},
 	}
 }
 
-func opArith(L *LState, inst uint32, baseframe *callFrame) int { //OP_ADD, OP_SUB, OP_MUL, OP_DIV, OP_MOD, OP_POW
+func opArith(L *LState, inst uint32, baseframe *callFrame) int { //op_ADD, op_SUB, op_MUL, op_DIV, op_MOD, op_POW
 	reg := L.reg
 	cf := L.currentFrame
 	lbase := cf.LocalBase
@@ -834,17 +834,17 @@ func luaModulo(lhs, rhs LNumber) LNumber {
 
 func numberArith(L *LState, opcode int, lhs, rhs LNumber) LNumber {
 	switch opcode {
-	case OP_ADD:
+	case op_ADD:
 		return lhs + rhs
-	case OP_SUB:
+	case op_SUB:
 		return lhs - rhs
-	case OP_MUL:
+	case op_MUL:
 		return lhs * rhs
-	case OP_DIV:
+	case op_DIV:
 		return lhs / rhs
-	case OP_MOD:
+	case op_MOD:
 		return luaModulo(lhs, rhs)
-	case OP_POW:
+	case op_POW:
 		flhs := float64(lhs)
 		frhs := float64(rhs)
 		return LNumber(math.Pow(flhs, frhs))
@@ -856,17 +856,17 @@ func numberArith(L *LState, opcode int, lhs, rhs LNumber) LNumber {
 func objectArith(L *LState, opcode int, lhs, rhs LValue) LValue {
 	event := ""
 	switch opcode {
-	case OP_ADD:
+	case op_ADD:
 		event = "__add"
-	case OP_SUB:
+	case op_SUB:
 		event = "__sub"
-	case OP_MUL:
+	case op_MUL:
 		event = "__mul"
-	case OP_DIV:
+	case op_DIV:
 		event = "__div"
-	case OP_MOD:
+	case op_MOD:
 		event = "__mod"
-	case OP_POW:
+	case op_POW:
 		event = "__pow"
 	}
 	op := L.metaOp2(lhs, rhs, event)

--- a/auxlib.go
+++ b/auxlib.go
@@ -364,7 +364,7 @@ func (ls *LState) LoadFile(path string) (*LFunction, error) {
 	if c == byte('#') {
 		// Unix exec. file?
 		// skip first line
-		_, err, _ = readBufioLine(reader)
+		_, _, err = readBufioLine(reader)
 		if err != nil {
 			return nil, newApiErrorE(ApiErrorFile, err)
 		}

--- a/baselib.go
+++ b/baselib.go
@@ -109,12 +109,12 @@ func baseGetFEnv(L *LState) int {
 		} else {
 			cf := L.currentFrame
 			for i := 0; i < level && cf != nil; i++ {
-				cf = cf.Parent
+				cf = cf.parent
 			}
-			if cf == nil || cf.Fn.IsG {
+			if cf == nil || cf.fn.IsG {
 				L.Push(L.G.Global)
 			} else {
-				L.Push(cf.Fn.Env)
+				L.Push(cf.fn.Env)
 			}
 		}
 		return 1
@@ -355,13 +355,13 @@ func baseSetFEnv(L *LState) int {
 
 		cf := L.currentFrame
 		for i := 0; i < level && cf != nil; i++ {
-			cf = cf.Parent
+			cf = cf.parent
 		}
-		if cf == nil || cf.Fn.IsG {
+		if cf == nil || cf.fn.IsG {
 			L.RaiseError("cannot change the environment of given object")
 		} else {
-			cf.Fn.Env = env
-			L.Push(cf.Fn)
+			cf.fn.Env = env
+			L.Push(cf.fn)
 			return 1
 		}
 	}
@@ -484,13 +484,13 @@ func loModule(L *LState) int {
 		L.SetField(tb, "_PACKAGE", LString(pname))
 	}
 
-	caller := L.currentFrame.Parent
+	caller := L.currentFrame.parent
 	if caller == nil {
 		L.RaiseError("no calling stack.")
-	} else if caller.Fn.IsG {
+	} else if caller.fn.IsG {
 		L.RaiseError("module() can not be called from GFunctions.")
 	}
-	L.SetFEnv(caller.Fn, tb)
+	L.SetFEnv(caller.fn, tb)
 
 	top := L.GetTop()
 	for i := 2; i <= top; i++ {

--- a/channellib.go
+++ b/channellib.go
@@ -46,7 +46,11 @@ func channelSelect(L *LState) int {
 	cases := make([]reflect.SelectCase, L.GetTop())
 	top := L.GetTop()
 	for i := 0; i < top; i++ {
-		cas := reflect.SelectCase{reflect.SelectSend, reflect.ValueOf(nil), reflect.ValueOf(nil)}
+		cas := reflect.SelectCase{
+			Dir:  reflect.SelectSend,
+			Chan: reflect.ValueOf(nil),
+			Send: reflect.ValueOf(nil),
+		}
 		tbl := L.CheckTable(i + 1)
 		dir, ok1 := tbl.RawGetInt(1).(LString)
 		if !ok1 {

--- a/compile.go
+++ b/compile.go
@@ -53,6 +53,9 @@ type lblabels struct {
 type constLValueExpr struct {
 	ast.ExprBase
 
+	// Value is a capitalized 'exported field'
+	// but it's not exported actually (it's in a unexported struct),
+	// because we want to keep consistency with structs in package ast.
 	Value LValue
 }
 

--- a/compile.go
+++ b/compile.go
@@ -255,8 +255,8 @@ func (cd *codeStore) Pop() {
 /* {{{ VarNamePool */
 
 type varNamePoolValue struct {
-	Index int
-	Name  string
+	index int
+	name  string
 }
 
 type varNamePool struct {
@@ -275,8 +275,8 @@ func (vp *varNamePool) Names() []string {
 func (vp *varNamePool) List() []varNamePoolValue {
 	result := make([]varNamePoolValue, len(vp.names), len(vp.names))
 	for i, name := range vp.names {
-		result[i].Index = i + vp.offset
-		result[i].Name = name
+		result[i].index = i + vp.offset
+		result[i].name = name
 	}
 	return result
 }
@@ -438,7 +438,7 @@ func (fc *funcContext) LeaveBlock() int {
 
 func (fc *funcContext) EndScope() {
 	for _, vr := range fc.block.localVars.List() {
-		fc.proto.DbgLocals[vr.Index].EndPc = fc.code.LastPC()
+		fc.proto.DbgLocals[vr.index].EndPc = fc.code.LastPC()
 	}
 }
 
@@ -1030,14 +1030,14 @@ func compileExpr(context *funcContext, reg int, expr ast.Expr, ec *expcontext) i
 		context.proto.FunctionPrototypes = append(context.proto.FunctionPrototypes, childcontext.proto)
 		code.AddABx(op_CLOSURE, sreg, protono, sline(ex))
 		for _, upvalue := range childcontext.upvalues.List() {
-			localidx, block := context.FindLocalVarAndBlock(upvalue.Name)
+			localidx, block := context.FindLocalVarAndBlock(upvalue.name)
 			if localidx > -1 {
 				code.AddABC(op_MOVE, 0, localidx, 0, sline(ex))
 				block.refUpvalue = true
 			} else {
-				upvalueidx := context.upvalues.Find(upvalue.Name)
+				upvalueidx := context.upvalues.Find(upvalue.name)
 				if upvalueidx < 0 {
-					upvalueidx = context.upvalues.RegisterUnique(upvalue.Name)
+					upvalueidx = context.upvalues.RegisterUnique(upvalue.name)
 				}
 				code.AddABC(op_GETUPVAL, 0, upvalueidx, 0, sline(ex))
 			}

--- a/compile.go
+++ b/compile.go
@@ -99,7 +99,7 @@ func savereg(ec *expcontext, reg int) int {
 
 func raiseCompileError(context *funcContext, line int, format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
-	panic(&CompileError{Context: context, Line: line, Message: msg})
+	panic(&CompileError{context: context, Line: line, Message: msg})
 }
 
 func isVarArgReturnExpr(expr ast.Expr) bool {
@@ -128,13 +128,13 @@ func lnumberValue(expr ast.Expr) (LNumber, bool) {
 /* utilities }}} */
 
 type CompileError struct { // {{{
-	Context *funcContext
+	context *funcContext
 	Line    int
 	Message string
 }
 
 func (e *CompileError) Error() string {
-	return fmt.Sprintf("compile error near line(%v) %v: %v", e.Line, e.Context.Proto.SourceName, e.Message)
+	return fmt.Sprintf("compile error near line(%v) %v: %v", e.Line, e.context.proto.SourceName, e.Message)
 } // }}}
 
 type codeStore struct { // {{{

--- a/coroutinelib.go
+++ b/coroutinelib.go
@@ -21,15 +21,15 @@ func coCreate(L *LState) int {
 	newthread, _ := L.NewThread()
 	base := 0
 	newthread.stack.Push(callFrame{
-		Fn:         fn,
-		Pc:         0,
-		Base:       base,
-		LocalBase:  base + 1,
-		ReturnBase: base,
-		NArgs:      0,
-		NRet:       MultRet,
-		Parent:     nil,
-		TailCall:   0,
+		fn:         fn,
+		pc:         0,
+		base:       base,
+		localBase:  base + 1,
+		returnBase: base,
+		nArgs:      0,
+		nRet:       MultRet,
+		parent:     nil,
+		tailCall:   0,
 	})
 	L.Push(newthread)
 	return 1
@@ -69,7 +69,7 @@ func coResume(L *LState) int {
 		th.SetTop(0)
 		nargs := L.GetTop() - 1
 		L.XMoveTo(th, nargs)
-		cf.NArgs = nargs
+		cf.nArgs = nargs
 		th.initCallFrame(cf)
 		th.Panic = panicWithoutTraceback
 	} else {

--- a/function.go
+++ b/function.go
@@ -134,7 +134,7 @@ func (fp *FunctionProto) str(level int, count int) string {
 	protono := 0
 	for no, code := range fp.Code {
 		inst := opGetOpCode(code)
-		if inst == OP_CLOSURE {
+		if inst == op_CLOSURE {
 			buf = append(buf, "\n")
 			buf = append(buf, fp.FunctionPrototypes[protono].str(level+1, protono))
 			buf = append(buf, "\n")

--- a/iolib.go
+++ b/iolib.go
@@ -341,9 +341,9 @@ func fileReadAux(L *LState, file *lFile, idx int) int {
 				file.reader.UnreadByte()
 			}
 			var buf []byte
-			var iseof bool
-			buf, err, iseof = readBufioSize(file.reader, size)
-			if iseof {
+			var empty bool
+			buf, empty, err = readBufioSize(file.reader, size)
+			if empty {
 				L.Push(LNil)
 				goto normalreturn
 			}
@@ -382,9 +382,9 @@ func fileReadAux(L *LState, file *lFile, idx int) int {
 					L.Push(LString(string(buf)))
 				case 'l':
 					var buf []byte
-					var iseof bool
-					buf, err, iseof = readBufioLine(file.reader)
-					if iseof {
+					var empty bool
+					buf, empty, err = readBufioLine(file.reader)
+					if empty {
 						L.Push(LNil)
 						goto normalreturn
 					}

--- a/opcode.go
+++ b/opcode.go
@@ -37,67 +37,67 @@ const opMaxArgBx = (1 << opSizeBx) - 1
 const opMaxArgSbx = opMaxArgBx >> 1
 
 const (
-	OP_MOVE     int = iota /*      A B     R(A) := R(B)                            */
-	OP_MOVEN               /*      A B     R(A) := R(B); followed by R(C) MOVE ops */
-	OP_LOADK               /*     A Bx    R(A) := Kst(Bx)                          */
-	OP_LOADBOOL            /*  A B C   R(A) := (Bool)B; if (C) pc++                */
-	OP_LOADNIL             /*   A B     R(A) := ... := R(B) := nil                 */
-	OP_GETUPVAL            /*  A B     R(A) := UpValue[B]                          */
+	op_MOVE     int = iota /*      A B     R(A) := R(B)                            */
+	op_MOVEN               /*      A B     R(A) := R(B); followed by R(C) MOVE ops */
+	op_LOADK               /*     A Bx    R(A) := Kst(Bx)                          */
+	op_LOADBOOL            /*  A B C   R(A) := (Bool)B; if (C) pc++                */
+	op_LOADNIL             /*   A B     R(A) := ... := R(B) := nil                 */
+	op_GETUPVAL            /*  A B     R(A) := UpValue[B]                          */
 
-	OP_GETGLOBAL  /* A Bx    R(A) := Gbl[Kst(Bx)]                            */
-	OP_GETTABLE   /*  A B C   R(A) := R(B)[RK(C)]                             */
-	OP_GETTABLEKS /*  A B C   R(A) := R(B)[RK(C)] ; RK(C) is constant string */
+	op_GETGLOBAL  /* A Bx    R(A) := Gbl[Kst(Bx)]                            */
+	op_GETTABLE   /*  A B C   R(A) := R(B)[RK(C)]                             */
+	op_GETTABLEKS /*  A B C   R(A) := R(B)[RK(C)] ; RK(C) is constant string */
 
-	OP_SETGLOBAL  /* A Bx    Gbl[Kst(Bx)] := R(A)                            */
-	OP_SETUPVAL   /*  A B     UpValue[B] := R(A)                              */
-	OP_SETTABLE   /*  A B C   R(A)[RK(B)] := RK(C)                            */
-	OP_SETTABLEKS /*  A B C   R(A)[RK(B)] := RK(C) ; RK(B) is constant string */
+	op_SETGLOBAL  /* A Bx    Gbl[Kst(Bx)] := R(A)                            */
+	op_SETUPVAL   /*  A B     UpValue[B] := R(A)                              */
+	op_SETTABLE   /*  A B C   R(A)[RK(B)] := RK(C)                            */
+	op_SETTABLEKS /*  A B C   R(A)[RK(B)] := RK(C) ; RK(B) is constant string */
 
-	OP_NEWTABLE /*  A B C   R(A) := {} (size = BC)                         */
+	op_NEWTABLE /*  A B C   R(A) := {} (size = BC)                         */
 
-	OP_SELF /*      A B C   R(A+1) := R(B); R(A) := R(B)[RK(C)]             */
+	op_SELF /*      A B C   R(A+1) := R(B); R(A) := R(B)[RK(C)]             */
 
-	OP_ADD /*       A B C   R(A) := RK(B) + RK(C)                           */
-	OP_SUB /*       A B C   R(A) := RK(B) - RK(C)                           */
-	OP_MUL /*       A B C   R(A) := RK(B) * RK(C)                           */
-	OP_DIV /*       A B C   R(A) := RK(B) / RK(C)                           */
-	OP_MOD /*       A B C   R(A) := RK(B) % RK(C)                           */
-	OP_POW /*       A B C   R(A) := RK(B) ^ RK(C)                           */
-	OP_UNM /*       A B     R(A) := -R(B)                                   */
-	OP_NOT /*       A B     R(A) := not R(B)                                */
-	OP_LEN /*       A B     R(A) := length of R(B)                          */
+	op_ADD /*       A B C   R(A) := RK(B) + RK(C)                           */
+	op_SUB /*       A B C   R(A) := RK(B) - RK(C)                           */
+	op_MUL /*       A B C   R(A) := RK(B) * RK(C)                           */
+	op_DIV /*       A B C   R(A) := RK(B) / RK(C)                           */
+	op_MOD /*       A B C   R(A) := RK(B) % RK(C)                           */
+	op_POW /*       A B C   R(A) := RK(B) ^ RK(C)                           */
+	op_UNM /*       A B     R(A) := -R(B)                                   */
+	op_NOT /*       A B     R(A) := not R(B)                                */
+	op_LEN /*       A B     R(A) := length of R(B)                          */
 
-	OP_CONCAT /*    A B C   R(A) := R(B).. ... ..R(C)                       */
+	op_CONCAT /*    A B C   R(A) := R(B).. ... ..R(C)                       */
 
-	OP_JMP /*       sBx     pc+=sBx                                 */
+	op_JMP /*       sBx     pc+=sBx                                 */
 
-	OP_EQ /*        A B C   if ((RK(B) == RK(C)) ~= A) then pc++            */
-	OP_LT /*        A B C   if ((RK(B) <  RK(C)) ~= A) then pc++            */
-	OP_LE /*        A B C   if ((RK(B) <= RK(C)) ~= A) then pc++            */
+	op_EQ /*        A B C   if ((RK(B) == RK(C)) ~= A) then pc++            */
+	op_LT /*        A B C   if ((RK(B) <  RK(C)) ~= A) then pc++            */
+	op_LE /*        A B C   if ((RK(B) <= RK(C)) ~= A) then pc++            */
 
-	OP_TEST    /*      A C     if not (R(A) <=> C) then pc++                   */
-	OP_TESTSET /*   A B C   if (R(B) <=> C) then R(A) := R(B) else pc++     */
+	op_TEST    /*      A C     if not (R(A) <=> C) then pc++                   */
+	op_TESTSET /*   A B C   if (R(B) <=> C) then R(A) := R(B) else pc++     */
 
-	OP_CALL     /*      A B C   R(A) ... R(A+C-2) := R(A)(R(A+1) ... R(A+B-1)) */
-	OP_TAILCALL /*  A B C   return R(A)(R(A+1) ... R(A+B-1))              */
-	OP_RETURN   /*    A B     return R(A) ... R(A+B-2)      (see note)      */
+	op_CALL     /*      A B C   R(A) ... R(A+C-2) := R(A)(R(A+1) ... R(A+B-1)) */
+	op_TAILCALL /*  A B C   return R(A)(R(A+1) ... R(A+B-1))              */
+	op_RETURN   /*    A B     return R(A) ... R(A+B-2)      (see note)      */
 
-	OP_FORLOOP /*   A sBx   R(A)+=R(A+2);
+	op_FORLOOP /*   A sBx   R(A)+=R(A+2);
 	     if R(A) <?= R(A+1) then { pc+=sBx; R(A+3)=R(A) }*/
-	OP_FORPREP /*   A sBx   R(A)-=R(A+2); pc+=sBx                           */
+	op_FORPREP /*   A sBx   R(A)-=R(A+2); pc+=sBx                           */
 
-	OP_TFORLOOP /*  A C     R(A+3) ... R(A+3+C) := R(A)(R(A+1) R(A+2));
+	op_TFORLOOP /*  A C     R(A+3) ... R(A+3+C) := R(A)(R(A+1) R(A+2));
 	    if R(A+3) ~= nil then { pc++; R(A+2)=R(A+3); }  */
-	OP_SETLIST /*   A B C   R(A)[(C-1)*FPF+i] := R(A+i) 1 <= i <= B        */
+	op_SETLIST /*   A B C   R(A)[(C-1)*FPF+i] := R(A+i) 1 <= i <= B        */
 
-	OP_CLOSE   /*     A       close all variables in the stack up to (>=) R(A)*/
-	OP_CLOSURE /*   A Bx    R(A) := closure(KPROTO[Bx] R(A) ... R(A+n))  */
+	op_CLOSE   /*     A       close all variables in the stack up to (>=) R(A)*/
+	op_CLOSURE /*   A Bx    R(A) := closure(KPROTO[Bx] R(A) ... R(A+n))  */
 
-	OP_VARARG /*     A B     R(A) R(A+1) ... R(A+B-1) = vararg            */
+	op_VARARG /*     A B     R(A) R(A+1) ... R(A+B-1) = vararg            */
 
-	OP_NOP /* NOP */
+	op_NOP /* NOP */
 )
-const opCodeMax = OP_NOP
+const opCodeMax = op_NOP
 
 type opArgMode int
 
@@ -282,89 +282,89 @@ func opToString(inst uint32) string {
 	}
 
 	switch op {
-	case OP_MOVE:
+	case op_MOVE:
 		buf += fmt.Sprintf("; R(%v) := R(%v)", arga, argb)
-	case OP_MOVEN:
+	case op_MOVEN:
 		buf += fmt.Sprintf("; R(%v) := R(%v); followed by %v MOVE ops", arga, argb, argc)
-	case OP_LOADK:
+	case op_LOADK:
 		buf += fmt.Sprintf("; R(%v) := Kst(%v)", arga, argbx)
-	case OP_LOADBOOL:
+	case op_LOADBOOL:
 		buf += fmt.Sprintf("; R(%v) := (Bool)%v; if (%v) pc++", arga, argb, argc)
-	case OP_LOADNIL:
+	case op_LOADNIL:
 		buf += fmt.Sprintf("; R(%v) := ... := R(%v) := nil", arga, argb)
-	case OP_GETUPVAL:
+	case op_GETUPVAL:
 		buf += fmt.Sprintf("; R(%v) := UpValue[%v]", arga, argb)
-	case OP_GETGLOBAL:
+	case op_GETGLOBAL:
 		buf += fmt.Sprintf("; R(%v) := Gbl[Kst(%v)]", arga, argbx)
-	case OP_GETTABLE:
+	case op_GETTABLE:
 		buf += fmt.Sprintf("; R(%v) := R(%v)[RK(%v)]", arga, argb, argc)
-	case OP_GETTABLEKS:
+	case op_GETTABLEKS:
 		buf += fmt.Sprintf("; R(%v) := R(%v)[RK(%v)] ; RK(%v) is constant string", arga, argb, argc, argc)
-	case OP_SETGLOBAL:
+	case op_SETGLOBAL:
 		buf += fmt.Sprintf("; Gbl[Kst(%v)] := R(%v)", argbx, arga)
-	case OP_SETUPVAL:
+	case op_SETUPVAL:
 		buf += fmt.Sprintf("; UpValue[%v] := R(%v)", argb, arga)
-	case OP_SETTABLE:
+	case op_SETTABLE:
 		buf += fmt.Sprintf("; R(%v)[RK(%v)] := RK(%v)", arga, argb, argc)
-	case OP_SETTABLEKS:
+	case op_SETTABLEKS:
 		buf += fmt.Sprintf("; R(%v)[RK(%v)] := RK(%v) ; RK(%v) is constant string", arga, argb, argc, argb)
-	case OP_NEWTABLE:
+	case op_NEWTABLE:
 		buf += fmt.Sprintf("; R(%v) := {} (size = BC)", arga)
-	case OP_SELF:
+	case op_SELF:
 		buf += fmt.Sprintf("; R(%v+1) := R(%v); R(%v) := R(%v)[RK(%v)]", arga, argb, arga, argb, argc)
-	case OP_ADD:
+	case op_ADD:
 		buf += fmt.Sprintf("; R(%v) := RK(%v) + RK(%v)", arga, argb, argc)
-	case OP_SUB:
+	case op_SUB:
 		buf += fmt.Sprintf("; R(%v) := RK(%v) - RK(%v)", arga, argb, argc)
-	case OP_MUL:
+	case op_MUL:
 		buf += fmt.Sprintf("; R(%v) := RK(%v) * RK(%v)", arga, argb, argc)
-	case OP_DIV:
+	case op_DIV:
 		buf += fmt.Sprintf("; R(%v) := RK(%v) / RK(%v)", arga, argb, argc)
-	case OP_MOD:
+	case op_MOD:
 		buf += fmt.Sprintf("; R(%v) := RK(%v) %% RK(%v)", arga, argb, argc)
-	case OP_POW:
+	case op_POW:
 		buf += fmt.Sprintf("; R(%v) := RK(%v) ^ RK(%v)", arga, argb, argc)
-	case OP_UNM:
+	case op_UNM:
 		buf += fmt.Sprintf("; R(%v) := -R(%v)", arga, argb)
-	case OP_NOT:
+	case op_NOT:
 		buf += fmt.Sprintf("; R(%v) := not R(%v)", arga, argb)
-	case OP_LEN:
+	case op_LEN:
 		buf += fmt.Sprintf("; R(%v) := length of R(%v)", arga, argb)
-	case OP_CONCAT:
+	case op_CONCAT:
 		buf += fmt.Sprintf("; R(%v) := R(%v).. ... ..R(%v)", arga, argb, argc)
-	case OP_JMP:
+	case op_JMP:
 		buf += fmt.Sprintf("; pc+=%v", argsbx)
-	case OP_EQ:
+	case op_EQ:
 		buf += fmt.Sprintf("; if ((RK(%v) == RK(%v)) ~= %v) then pc++", argb, argc, arga)
-	case OP_LT:
+	case op_LT:
 		buf += fmt.Sprintf("; if ((RK(%v) <  RK(%v)) ~= %v) then pc++", argb, argc, arga)
-	case OP_LE:
+	case op_LE:
 		buf += fmt.Sprintf("; if ((RK(%v) <= RK(%v)) ~= %v) then pc++", argb, argc, arga)
-	case OP_TEST:
+	case op_TEST:
 		buf += fmt.Sprintf("; if not (R(%v) <=> %v) then pc++", arga, argc)
-	case OP_TESTSET:
+	case op_TESTSET:
 		buf += fmt.Sprintf("; if (R(%v) <=> %v) then R(%v) := R(%v) else pc++", argb, argc, arga, argb)
-	case OP_CALL:
+	case op_CALL:
 		buf += fmt.Sprintf("; R(%v) ... R(%v+%v-2) := R(%v)(R(%v+1) ... R(%v+%v-1))", arga, arga, argc, arga, arga, arga, argb)
-	case OP_TAILCALL:
+	case op_TAILCALL:
 		buf += fmt.Sprintf("; return R(%v)(R(%v+1) ... R(%v+%v-1))", arga, arga, arga, argb)
-	case OP_RETURN:
+	case op_RETURN:
 		buf += fmt.Sprintf("; return R(%v) ... R(%v+%v-2)", arga, arga, argb)
-	case OP_FORLOOP:
+	case op_FORLOOP:
 		buf += fmt.Sprintf("; R(%v)+=R(%v+2); if R(%v) <?= R(%v+1) then { pc+=%v; R(%v+3)=R(%v) }", arga, arga, arga, arga, argsbx, arga, arga)
-	case OP_FORPREP:
+	case op_FORPREP:
 		buf += fmt.Sprintf("; R(%v)-=R(%v+2); pc+=%v", arga, arga, argsbx)
-	case OP_TFORLOOP:
+	case op_TFORLOOP:
 		buf += fmt.Sprintf("; R(%v+3) ... R(%v+3+%v) := R(%v)(R(%v+1) R(%v+2)); if R(%v+3) ~= nil then { pc++; R(%v+2)=R(%v+3); }", arga, arga, argc, arga, arga, arga, arga, arga, arga)
-	case OP_SETLIST:
+	case op_SETLIST:
 		buf += fmt.Sprintf("; R(%v)[(%v-1)*FPF+i] := R(%v+i) 1 <= i <= %v", arga, argc, arga, argb)
-	case OP_CLOSE:
+	case op_CLOSE:
 		buf += fmt.Sprintf("; close all variables in the stack up to (>=) R(%v)", arga)
-	case OP_CLOSURE:
+	case op_CLOSURE:
 		buf += fmt.Sprintf("; R(%v) := closure(KPROTO[%v] R(%v) ... R(%v+n))", arga, argbx, arga, arga)
-	case OP_VARARG:
+	case op_VARARG:
 		buf += fmt.Sprintf(";  R(%v) R(%v+1) ... R(%v+%v-1) = vararg", arga, arga, arga, argb)
-	case OP_NOP:
+	case op_NOP:
 		/* nothing to do */
 	}
 	return buf

--- a/opcode.go
+++ b/opcode.go
@@ -117,12 +117,12 @@ const (
 )
 
 type opProp struct {
-	Name     string
-	IsTest   bool
-	SetRegA  bool
-	ModeArgB opArgMode
-	ModeArgC opArgMode
-	Type     opType
+	name     string
+	isTest   bool
+	setRegA  bool
+	modeArgB opArgMode
+	modeArgC opArgMode
+	optype   opType
 }
 
 var opProps = []opProp{
@@ -272,13 +272,13 @@ func opToString(inst uint32) string {
 	argsbx := opGetArgSbx(inst)
 
 	buf := ""
-	switch prop.Type {
+	switch prop.optype {
 	case opTypeABC:
-		buf = fmt.Sprintf("%s      |  %d, %d, %d", prop.Name, arga, argb, argc)
+		buf = fmt.Sprintf("%s      |  %d, %d, %d", prop.name, arga, argb, argc)
 	case opTypeABx:
-		buf = fmt.Sprintf("%s      |  %d, %d", prop.Name, arga, argbx)
+		buf = fmt.Sprintf("%s      |  %d, %d", prop.name, arga, argbx)
 	case opTypeASbx:
-		buf = fmt.Sprintf("%s      |  %d, %d", prop.Name, arga, argsbx)
+		buf = fmt.Sprintf("%s      |  %d, %d", prop.name, arga, argsbx)
 	}
 
 	switch op {

--- a/pm/pm.go
+++ b/pm/pm.go
@@ -77,21 +77,21 @@ func (st *MatchData) Capture(idx int) int { return int(st.captures[idx] >> 1) }
 /* scanner {{{ */
 
 type scannerState struct {
-	Pos     int
+	pos     int
 	started bool
 }
 
 type scanner struct {
 	src   []byte
-	State scannerState
+	state scannerState
 	saved scannerState
 }
 
 func newScanner(src []byte) *scanner {
 	return &scanner{
 		src: src,
-		State: scannerState{
-			Pos:     0,
+		state: scannerState{
+			pos:     0,
 			started: false,
 		},
 		saved: scannerState{},
@@ -101,55 +101,55 @@ func newScanner(src []byte) *scanner {
 func (sc *scanner) Length() int { return len(sc.src) }
 
 func (sc *scanner) Next() int {
-	if !sc.State.started {
-		sc.State.started = true
+	if !sc.state.started {
+		sc.state.started = true
 		if len(sc.src) == 0 {
-			sc.State.Pos = EOS
+			sc.state.pos = EOS
 		}
 	} else {
-		sc.State.Pos = sc.NextPos()
+		sc.state.pos = sc.NextPos()
 	}
-	if sc.State.Pos == EOS {
+	if sc.state.pos == EOS {
 		return EOS
 	}
-	return int(sc.src[sc.State.Pos])
+	return int(sc.src[sc.state.pos])
 }
 
 func (sc *scanner) CurrentPos() int {
-	return sc.State.Pos
+	return sc.state.pos
 }
 
 func (sc *scanner) NextPos() int {
-	if sc.State.Pos == EOS || sc.State.Pos >= len(sc.src)-1 {
+	if sc.state.pos == EOS || sc.state.pos >= len(sc.src)-1 {
 		return EOS
 	}
-	if !sc.State.started {
+	if !sc.state.started {
 		return 0
 	} else {
-		return sc.State.Pos + 1
+		return sc.state.pos + 1
 	}
 }
 
 func (sc *scanner) Peek() int {
-	cureof := sc.State.Pos == EOS
+	cureof := sc.state.pos == EOS
 	ch := sc.Next()
 	if !cureof {
-		if sc.State.Pos == EOS {
-			sc.State.Pos = len(sc.src) - 1
+		if sc.state.pos == EOS {
+			sc.state.pos = len(sc.src) - 1
 		} else {
-			sc.State.Pos--
-			if sc.State.Pos < 0 {
-				sc.State.Pos = 0
-				sc.State.started = false
+			sc.state.pos--
+			if sc.state.pos < 0 {
+				sc.state.pos = 0
+				sc.state.started = false
 			}
 		}
 	}
 	return ch
 }
 
-func (sc *scanner) Save() { sc.saved = sc.State }
+func (sc *scanner) Save() { sc.saved = sc.state }
 
-func (sc *scanner) Restore() { sc.State = sc.saved }
+func (sc *scanner) Restore() { sc.state = sc.saved }
 
 /* }}} */
 

--- a/pm/pm.go
+++ b/pm/pm.go
@@ -170,8 +170,8 @@ const (
 )
 
 type inst struct {
-	OpCode   opCode
-	Class    class
+	code     opCode
+	cls      class
 	Operand1 int
 	Operand2 int
 }
@@ -531,9 +531,9 @@ func recursiveVM(src []byte, insts []inst, pc, sp int, ms ...*MatchData) (bool, 
 	}
 redo:
 	inst := insts[pc]
-	switch inst.OpCode {
+	switch inst.code {
 	case opChar:
-		if sp >= len(src) || !inst.Class.Matches(int(src[sp])) {
+		if sp >= len(src) || !inst.cls.Matches(int(src[sp])) {
 			return false, sp, m
 		}
 		pc++

--- a/stringlib.go
+++ b/stringlib.go
@@ -173,8 +173,8 @@ func strGsub(L *LState) int {
 }
 
 type replaceInfo struct {
-	Indicies []int
-	String   string
+	indicies []int
+	str      string
 }
 
 func checkCaptureIndex(L *LState, m *pm.MatchData, idx int) {
@@ -204,13 +204,13 @@ func strGsubDoReplace(str string, info []replaceInfo) string {
 	buf := []byte(str)
 	for _, replace := range info {
 		oldlen := len(buf)
-		b1 := append([]byte(""), buf[0:offset+replace.Indicies[0]]...)
+		b1 := append([]byte(""), buf[0:offset+replace.indicies[0]]...)
 		b2 := []byte("")
-		index2 := offset + replace.Indicies[1]
+		index2 := offset + replace.indicies[1]
 		if index2 <= len(buf) {
 			b2 = append(b2, buf[index2:len(buf)]...)
 		}
-		buf = append(b1, replace.String...)
+		buf = append(b1, replace.str...)
 		buf = append(buf, b2...)
 		offset += len(buf) - oldlen
 	}

--- a/stringlib.go
+++ b/stringlib.go
@@ -223,15 +223,15 @@ func strGsubStr(L *LState, str string, repl string, matches []*pm.MatchData) str
 		start, end := match.Capture(0), match.Capture(1)
 		sc := newFlagScanner('%', "", "", repl)
 		for c, eos := sc.Next(); !eos; c, eos = sc.Next() {
-			if !sc.ChangeFlag {
-				if sc.HasFlag {
+			if !sc.changeFlag {
+				if sc.hasFlag {
 					if c >= '0' && c <= '9' {
 						sc.AppendString(capturedString(L, match, str, 2*(int(c)-48)))
 					} else {
 						sc.AppendChar('%')
 						sc.AppendChar(c)
 					}
-					sc.HasFlag = false
+					sc.hasFlag = false
 				} else {
 					sc.AppendChar(c)
 				}

--- a/utils.go
+++ b/utils.go
@@ -75,22 +75,21 @@ func (fs *flagScanner) Next() (byte, bool) {
 			fs.AppendString(fs.end)
 		}
 		return c, true
-	} else {
-		c = fs.str[fs.Pos]
-		if c == fs.flag {
-			if fs.Pos < (fs.Length-1) && fs.str[fs.Pos+1] == fs.flag {
-				fs.HasFlag = false
-				fs.AppendChar(fs.flag)
-				fs.Pos += 2
-				return fs.Next()
-			} else if fs.Pos != fs.Length-1 {
-				if fs.HasFlag {
-					fs.AppendString(fs.end)
-				}
-				fs.AppendString(fs.start)
-				fs.ChangeFlag = true
-				fs.HasFlag = true
+	}
+	c = fs.str[fs.Pos]
+	if c == fs.flag {
+		if fs.Pos < (fs.Length-1) && fs.str[fs.Pos+1] == fs.flag {
+			fs.HasFlag = false
+			fs.AppendChar(fs.flag)
+			fs.Pos += 2
+			return fs.Next()
+		} else if fs.Pos != fs.Length-1 {
+			if fs.HasFlag {
+				fs.AppendString(fs.end)
 			}
+			fs.AppendString(fs.start)
+			fs.ChangeFlag = true
+			fs.HasFlag = true
 		}
 	}
 	fs.Pos++
@@ -139,18 +138,16 @@ func isArrayKey(v LNumber) bool {
 }
 
 func parseNumber(number string) (LNumber, error) {
-	var value LNumber
 	number = strings.Trim(number, " \t\n")
-	if v, err := strconv.ParseInt(number, 0, LNumberBit); err != nil {
-		if v2, err2 := strconv.ParseFloat(number, LNumberBit); err2 != nil {
-			return LNumber(0), err2
-		} else {
-			value = LNumber(v2)
-		}
-	} else {
-		value = LNumber(v)
+	vi, err := strconv.ParseInt(number, 0, LNumberBit)
+	if err == nil {
+		return LNumber(vi), nil
 	}
-	return value, nil
+	vf, err := strconv.ParseFloat(number, LNumberBit)
+	if err == nil {
+		return LNumber(vf), nil
+	}
+	return LNumber(0), err
 }
 
 func popenArgs(arg string) (string, []string) {

--- a/utils.go
+++ b/utils.go
@@ -175,7 +175,7 @@ func isGoroutineSafe(lv LValue) bool {
 	}
 }
 
-func readBufioSize(reader *bufio.Reader, size int64) ([]byte, error, bool) {
+func readBufioSize(reader *bufio.Reader, size int64) ([]byte, bool, error) {
 	result := []byte{}
 	read := int64(0)
 	var err error
@@ -190,14 +190,14 @@ func readBufioSize(reader *bufio.Reader, size int64) ([]byte, error, bool) {
 		result = append(result, buf[:n]...)
 	}
 	e := err
-	if e != nil && e == io.EOF {
+	if e == io.EOF {
 		e = nil
 	}
 
-	return result, e, len(result) == 0 && err == io.EOF
+	return result, len(result) == 0 && err == io.EOF, e
 }
 
-func readBufioLine(reader *bufio.Reader) ([]byte, error, bool) {
+func readBufioLine(reader *bufio.Reader) ([]byte, bool, error) {
 	result := []byte{}
 	var buf []byte
 	var err error
@@ -210,11 +210,11 @@ func readBufioLine(reader *bufio.Reader) ([]byte, error, bool) {
 		result = append(result, buf...)
 	}
 	e := err
-	if e != nil && e == io.EOF {
+	if e == io.EOF {
 		e = nil
 	}
 
-	return result, e, len(result) == 0 && err == io.EOF
+	return result, len(result) == 0 && err == io.EOF, e
 }
 
 func int2Fb(val int) int {

--- a/utils.go
+++ b/utils.go
@@ -51,10 +51,10 @@ type flagScanner struct {
 	end        string
 	buf        []byte
 	str        string
-	Length     int
-	Pos        int
-	HasFlag    bool
-	ChangeFlag bool
+	length     int
+	pos        int
+	hasFlag    bool
+	changeFlag bool
 }
 
 func newFlagScanner(flag byte, start, end, str string) *flagScanner {
@@ -69,30 +69,30 @@ func (fs *flagScanner) String() string { return string(fs.buf) }
 
 func (fs *flagScanner) Next() (byte, bool) {
 	c := byte('\000')
-	fs.ChangeFlag = false
-	if fs.Pos == fs.Length {
-		if fs.HasFlag {
+	fs.changeFlag = false
+	if fs.pos == fs.length {
+		if fs.hasFlag {
 			fs.AppendString(fs.end)
 		}
 		return c, true
 	}
-	c = fs.str[fs.Pos]
+	c = fs.str[fs.pos]
 	if c == fs.flag {
-		if fs.Pos < (fs.Length-1) && fs.str[fs.Pos+1] == fs.flag {
-			fs.HasFlag = false
+		if fs.pos < (fs.length-1) && fs.str[fs.pos+1] == fs.flag {
+			fs.hasFlag = false
 			fs.AppendChar(fs.flag)
-			fs.Pos += 2
+			fs.pos += 2
 			return fs.Next()
-		} else if fs.Pos != fs.Length-1 {
-			if fs.HasFlag {
+		} else if fs.pos != fs.length-1 {
+			if fs.hasFlag {
 				fs.AppendString(fs.end)
 			}
 			fs.AppendString(fs.start)
-			fs.ChangeFlag = true
-			fs.HasFlag = true
+			fs.changeFlag = true
+			fs.hasFlag = true
 		}
 	}
-	fs.Pos++
+	fs.pos++
 	return c, false
 }
 
@@ -104,8 +104,8 @@ var cDateFlagToGo = map[byte]string{
 func strftime(t time.Time, cfmt string) string {
 	sc := newFlagScanner('%', "", "", cfmt)
 	for c, eos := sc.Next(); !eos; c, eos = sc.Next() {
-		if !sc.ChangeFlag {
-			if sc.HasFlag {
+		if !sc.changeFlag {
+			if sc.hasFlag {
 				if v, ok := cDateFlagToGo[c]; ok {
 					sc.AppendString(t.Format(v))
 				} else {
@@ -117,7 +117,7 @@ func strftime(t time.Time, cfmt string) string {
 						sc.AppendChar(c)
 					}
 				}
-				sc.HasFlag = false
+				sc.hasFlag = false
 			} else {
 				sc.AppendChar(c)
 			}

--- a/vm.go
+++ b/vm.go
@@ -199,7 +199,7 @@ var jumpTable [opCodeMax + 1]instFunc
 
 func init() {
 	jumpTable = [opCodeMax + 1]instFunc{
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_MOVE
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_MOVE
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -209,7 +209,7 @@ func init() {
 			reg.Set(RA, reg.Get(lbase+B))
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_MOVEN
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_MOVEN
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -229,7 +229,7 @@ func init() {
 			cf.Pc = pc
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_LOADK
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_LOADK
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -239,7 +239,7 @@ func init() {
 			reg.Set(RA, cf.Fn.Proto.Constants[Bx])
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_LOADBOOL
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_LOADBOOL
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -257,7 +257,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_LOADNIL
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_LOADNIL
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -269,7 +269,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_GETUPVAL
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_GETUPVAL
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -279,7 +279,7 @@ func init() {
 			reg.Set(RA, cf.Fn.Upvalues[B].Value())
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_GETGLOBAL
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_GETGLOBAL
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -290,7 +290,7 @@ func init() {
 			reg.Set(RA, L.getFieldString(cf.Fn.Env, cf.Fn.Proto.stringConstants[Bx]))
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_GETTABLE
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_GETTABLE
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -301,7 +301,7 @@ func init() {
 			reg.Set(RA, L.getField(reg.Get(lbase+B), L.rkValue(C)))
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_GETTABLEKS
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_GETTABLEKS
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -312,7 +312,7 @@ func init() {
 			reg.Set(RA, L.getFieldString(reg.Get(lbase+B), L.rkString(C)))
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_SETGLOBAL
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_SETGLOBAL
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -323,7 +323,7 @@ func init() {
 			L.setFieldString(cf.Fn.Env, cf.Fn.Proto.stringConstants[Bx], reg.Get(RA))
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_SETUPVAL
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_SETUPVAL
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -333,7 +333,7 @@ func init() {
 			cf.Fn.Upvalues[B].SetValue(reg.Get(RA))
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_SETTABLE
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_SETTABLE
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -344,7 +344,7 @@ func init() {
 			L.setField(reg.Get(RA), L.rkValue(B), L.rkValue(C))
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_SETTABLEKS
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_SETTABLEKS
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -355,7 +355,7 @@ func init() {
 			L.setFieldString(reg.Get(RA), L.rkString(B), L.rkValue(C))
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_NEWTABLE
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_NEWTABLE
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -366,7 +366,7 @@ func init() {
 			reg.Set(RA, newLTable(B, C))
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_SELF
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_SELF
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -379,13 +379,13 @@ func init() {
 			reg.Set(RA+1, selfobj)
 			return 0
 		},
-		opArith, // OP_ADD
-		opArith, // OP_SUB
-		opArith, // OP_MUL
-		opArith, // OP_DIV
-		opArith, // OP_MOD
-		opArith, // OP_POW
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_UNM
+		opArith, // op_ADD
+		opArith, // op_SUB
+		opArith, // op_MUL
+		opArith, // op_DIV
+		opArith, // op_MOD
+		opArith, // op_POW
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_UNM
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -414,7 +414,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_NOT
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_NOT
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -428,7 +428,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_LEN
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_LEN
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -453,7 +453,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_CONCAT
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_CONCAT
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -466,13 +466,13 @@ func init() {
 			reg.Set(RA, stringConcat(L, RC-RB+1, RC))
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_JMP
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_JMP
 			cf := L.currentFrame
 			Sbx := int(inst&0x3ffff) - opMaxArgSbx //GETSBX
 			cf.Pc += Sbx
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_EQ
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_EQ
 			cf := L.currentFrame
 			A := int(inst>>18) & 0xff //GETA
 			B := int(inst & 0x1ff)    //GETB
@@ -487,7 +487,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_LT
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_LT
 			cf := L.currentFrame
 			A := int(inst>>18) & 0xff //GETA
 			B := int(inst & 0x1ff)    //GETB
@@ -502,7 +502,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_LE
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_LE
 			cf := L.currentFrame
 			A := int(inst>>18) & 0xff //GETA
 			B := int(inst & 0x1ff)    //GETB
@@ -545,7 +545,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_TEST
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_TEST
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -557,7 +557,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_TESTSET
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_TESTSET
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -572,7 +572,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_CALL
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_CALL
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -701,7 +701,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_TAILCALL
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_TAILCALL
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -874,7 +874,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_RETURN
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_RETURN
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -989,7 +989,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_FORLOOP
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_FORLOOP
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -1018,7 +1018,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_FORPREP
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_FORPREP
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -1037,7 +1037,7 @@ func init() {
 			cf.Pc += Sbx
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_TFORLOOP
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_TFORLOOP
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -1058,7 +1058,7 @@ func init() {
 			cf.Pc++
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_SETLIST
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_SETLIST
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -1081,7 +1081,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_CLOSE
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_CLOSE
 			cf := L.currentFrame
 			lbase := cf.LocalBase
 			A := int(inst>>18) & 0xff //GETA
@@ -1108,7 +1108,7 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_CLOSURE
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_CLOSURE
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -1123,15 +1123,15 @@ func init() {
 				cf.Pc++
 				B := opGetArgB(inst)
 				switch opGetOpCode(inst) {
-				case OP_MOVE:
+				case op_MOVE:
 					closure.Upvalues[i] = L.findUpvalue(lbase + B)
-				case OP_GETUPVAL:
+				case op_GETUPVAL:
 					closure.Upvalues[i] = cf.Fn.Upvalues[B]
 				}
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_VARARG
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_VARARG
 			reg := L.reg
 			cf := L.currentFrame
 			lbase := cf.LocalBase
@@ -1166,13 +1166,13 @@ func init() {
 			}
 			return 0
 		},
-		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_NOP
+		func(L *LState, inst uint32, baseframe *callFrame) int { //op_NOP
 			return 0
 		},
 	}
 }
 
-func opArith(L *LState, inst uint32, baseframe *callFrame) int { //OP_ADD, OP_SUB, OP_MUL, OP_DIV, OP_MOD, OP_POW
+func opArith(L *LState, inst uint32, baseframe *callFrame) int { //op_ADD, op_SUB, op_MUL, op_DIV, op_MOD, op_POW
 	reg := L.reg
 	cf := L.currentFrame
 	lbase := cf.LocalBase
@@ -1205,17 +1205,17 @@ func luaModulo(lhs, rhs LNumber) LNumber {
 
 func numberArith(L *LState, opcode int, lhs, rhs LNumber) LNumber {
 	switch opcode {
-	case OP_ADD:
+	case op_ADD:
 		return lhs + rhs
-	case OP_SUB:
+	case op_SUB:
 		return lhs - rhs
-	case OP_MUL:
+	case op_MUL:
 		return lhs * rhs
-	case OP_DIV:
+	case op_DIV:
 		return lhs / rhs
-	case OP_MOD:
+	case op_MOD:
 		return luaModulo(lhs, rhs)
-	case OP_POW:
+	case op_POW:
 		flhs := float64(lhs)
 		frhs := float64(rhs)
 		return LNumber(math.Pow(flhs, frhs))
@@ -1227,17 +1227,17 @@ func numberArith(L *LState, opcode int, lhs, rhs LNumber) LNumber {
 func objectArith(L *LState, opcode int, lhs, rhs LValue) LValue {
 	event := ""
 	switch opcode {
-	case OP_ADD:
+	case op_ADD:
 		event = "__add"
-	case OP_SUB:
+	case op_SUB:
 		event = "__sub"
-	case OP_MUL:
+	case op_MUL:
 		event = "__mul"
-	case OP_DIV:
+	case op_DIV:
 		event = "__div"
-	case OP_MOD:
+	case op_MOD:
 		event = "__mod"
-	case OP_POW:
+	case op_POW:
 		event = "__pow"
 	}
 	op := L.metaOp2(lhs, rhs, event)

--- a/vm.go
+++ b/vm.go
@@ -19,15 +19,15 @@ func mainLoop(L *LState, baseframe *callFrame) {
 	}
 
 	L.currentFrame = L.stack.Last()
-	if L.currentFrame.Fn.IsG {
+	if L.currentFrame.fn.IsG {
 		callGFunction(L, false)
 		return
 	}
 
 	for {
 		cf = L.currentFrame
-		inst = cf.Fn.Proto.Code[cf.Pc]
-		cf.Pc++
+		inst = cf.fn.Proto.Code[cf.pc]
+		cf.pc++
 		if jumpTable[int(inst>>26)](L, inst, baseframe) == 1 {
 			return
 		}
@@ -43,15 +43,15 @@ func mainLoopWithContext(L *LState, baseframe *callFrame) {
 	}
 
 	L.currentFrame = L.stack.Last()
-	if L.currentFrame.Fn.IsG {
+	if L.currentFrame.fn.IsG {
 		callGFunction(L, false)
 		return
 	}
 
 	for {
 		cf = L.currentFrame
-		inst = cf.Fn.Proto.Code[cf.Pc]
-		cf.Pc++
+		inst = cf.fn.Proto.Code[cf.pc]
+		cf.pc++
 		select {
 		case <-L.ctx.Done():
 			L.RaiseError(L.ctx.Err().Error())
@@ -110,7 +110,7 @@ func switchToParentThread(L *LState, nargs int, haserror bool, kill bool) {
 	}
 	L.XMoveTo(parent, nargs)
 	L.stack.Pop()
-	offset := L.currentFrame.LocalBase - L.currentFrame.ReturnBase
+	offset := L.currentFrame.localBase - L.currentFrame.returnBase
 	L.currentFrame = L.stack.Last()
 	L.reg.SetTop(L.reg.Top() - offset) // remove 'yield' function(including tailcalled functions)
 	if kill {
@@ -120,7 +120,7 @@ func switchToParentThread(L *LState, nargs int, haserror bool, kill bool) {
 
 func callGFunction(L *LState, tailcall bool) bool {
 	frame := L.currentFrame
-	gfnret := frame.Fn.GFunction(L)
+	gfnret := frame.fn.GFunction(L)
 	if tailcall {
 		L.stack.Remove(L.stack.Sp() - 2) // remove caller lua function frame
 		L.currentFrame = L.stack.Last()
@@ -131,7 +131,7 @@ func callGFunction(L *LState, tailcall bool) bool {
 		return true
 	}
 
-	wantret := frame.NRet
+	wantret := frame.nRet
 	if wantret == MultRet {
 		wantret = gfnret
 	}
@@ -145,7 +145,7 @@ func callGFunction(L *LState, tailcall bool) bool {
 	// source function is 'func (rg *registry) CopyRange(regv, start, limit, n int) ' in '_state.go'
 	{
 		rg := L.reg
-		regv := frame.ReturnBase
+		regv := frame.returnBase
 		start := L.reg.Top() - gfnret
 		limit := -1
 		n := wantret
@@ -202,7 +202,7 @@ func init() {
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_MOVE
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			B := int(inst & 0x1ff) //GETB
@@ -212,13 +212,13 @@ func init() {
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_MOVEN
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			B := int(inst & 0x1ff)    //GETB
 			C := int(inst>>9) & 0x1ff //GETC
 			reg.Set(lbase+A, reg.Get(lbase+B))
-			code := cf.Fn.Proto.Code
-			pc := cf.Pc
+			code := cf.fn.Proto.Code
+			pc := cf.pc
 			for i := 0; i < C; i++ {
 				inst = code[pc]
 				pc++
@@ -226,23 +226,23 @@ func init() {
 				B = int(inst & 0x1ff)    //GETB
 				reg.Set(lbase+A, reg.Get(lbase+B))
 			}
-			cf.Pc = pc
+			cf.pc = pc
 			return 0
 		},
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_LOADK
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			Bx := int(inst & 0x3ffff) //GETBX
-			reg.Set(RA, cf.Fn.Proto.Constants[Bx])
+			reg.Set(RA, cf.fn.Proto.Constants[Bx])
 			return 0
 		},
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_LOADBOOL
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			B := int(inst & 0x1ff)    //GETB
@@ -253,14 +253,14 @@ func init() {
 				reg.Set(RA, LFalse)
 			}
 			if C != 0 {
-				cf.Pc++
+				cf.pc++
 			}
 			return 0
 		},
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_LOADNIL
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			B := int(inst & 0x1ff) //GETB
@@ -272,28 +272,28 @@ func init() {
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_GETUPVAL
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			B := int(inst & 0x1ff) //GETB
-			reg.Set(RA, cf.Fn.Upvalues[B].Value())
+			reg.Set(RA, cf.fn.Upvalues[B].Value())
 			return 0
 		},
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_GETGLOBAL
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			Bx := int(inst & 0x3ffff) //GETBX
-			//reg.Set(RA, L.getField(cf.Fn.Env, cf.Fn.Proto.Constants[Bx]))
-			reg.Set(RA, L.getFieldString(cf.Fn.Env, cf.Fn.Proto.stringConstants[Bx]))
+			//reg.Set(RA, L.getField(cf.fn.Env, cf.fn.Proto.Constants[Bx]))
+			reg.Set(RA, L.getFieldString(cf.fn.Env, cf.fn.Proto.stringConstants[Bx]))
 			return 0
 		},
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_GETTABLE
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			B := int(inst & 0x1ff)    //GETB
@@ -304,7 +304,7 @@ func init() {
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_GETTABLEKS
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			B := int(inst & 0x1ff)    //GETB
@@ -315,28 +315,28 @@ func init() {
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_SETGLOBAL
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			Bx := int(inst & 0x3ffff) //GETBX
-			//L.setField(cf.Fn.Env, cf.Fn.Proto.Constants[Bx], reg.Get(RA))
-			L.setFieldString(cf.Fn.Env, cf.Fn.Proto.stringConstants[Bx], reg.Get(RA))
+			//L.setField(cf.fn.Env, cf.fn.Proto.Constants[Bx], reg.Get(RA))
+			L.setFieldString(cf.fn.Env, cf.fn.Proto.stringConstants[Bx], reg.Get(RA))
 			return 0
 		},
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_SETUPVAL
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			B := int(inst & 0x1ff) //GETB
-			cf.Fn.Upvalues[B].SetValue(reg.Get(RA))
+			cf.fn.Upvalues[B].SetValue(reg.Get(RA))
 			return 0
 		},
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_SETTABLE
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			B := int(inst & 0x1ff)    //GETB
@@ -347,7 +347,7 @@ func init() {
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_SETTABLEKS
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			B := int(inst & 0x1ff)    //GETB
@@ -358,7 +358,7 @@ func init() {
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_NEWTABLE
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			B := int(inst & 0x1ff)    //GETB
@@ -369,7 +369,7 @@ func init() {
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_SELF
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			B := int(inst & 0x1ff)    //GETB
@@ -388,7 +388,7 @@ func init() {
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_UNM
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			B := int(inst & 0x1ff) //GETB
@@ -417,7 +417,7 @@ func init() {
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_NOT
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			B := int(inst & 0x1ff) //GETB
@@ -431,7 +431,7 @@ func init() {
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_LEN
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			B := int(inst & 0x1ff) //GETB
@@ -456,7 +456,7 @@ func init() {
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_CONCAT
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			B := int(inst & 0x1ff)    //GETB
@@ -469,7 +469,7 @@ func init() {
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_JMP
 			cf := L.currentFrame
 			Sbx := int(inst&0x3ffff) - opMaxArgSbx //GETSBX
-			cf.Pc += Sbx
+			cf.pc += Sbx
 			return 0
 		},
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_EQ
@@ -483,7 +483,7 @@ func init() {
 				v = 0
 			}
 			if v == A {
-				cf.Pc++
+				cf.pc++
 			}
 			return 0
 		},
@@ -498,7 +498,7 @@ func init() {
 				v = 0
 			}
 			if v == A {
-				cf.Pc++
+				cf.pc++
 			}
 			return 0
 		},
@@ -541,26 +541,26 @@ func init() {
 				v = 0
 			}
 			if v == A {
-				cf.Pc++
+				cf.pc++
 			}
 			return 0
 		},
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_TEST
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			C := int(inst>>9) & 0x1ff //GETC
 			if LVAsBool(reg.Get(RA)) == (C == 0) {
-				cf.Pc++
+				cf.pc++
 			}
 			return 0
 		},
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_TESTSET
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			B := int(inst & 0x1ff)    //GETB
@@ -568,14 +568,14 @@ func init() {
 			if value := reg.Get(lbase + B); LVAsBool(value) != (C == 0) {
 				reg.Set(RA, value)
 			} else {
-				cf.Pc++
+				cf.pc++
 			}
 			return 0
 		},
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_CALL
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			B := int(inst & 0x1ff)    //GETB
@@ -598,13 +598,13 @@ func init() {
 			// source function is 'func (ls *LState) pushCallFrame(cf callFrame, fn LValue, meta bool) ' in '_state.go'
 			{
 				ls := L
-				cf := callFrame{Fn: callable, Pc: 0, Base: RA, LocalBase: RA + 1, ReturnBase: RA, NArgs: nargs, NRet: nret, Parent: cf, TailCall: 0}
+				cf := callFrame{fn: callable, pc: 0, base: RA, localBase: RA + 1, returnBase: RA, nArgs: nargs, nRet: nret, parent: cf, tailCall: 0}
 				fn := lv
 				if meta {
-					cf.NArgs++
-					ls.reg.Insert(fn, cf.LocalBase)
+					cf.nArgs++
+					ls.reg.Insert(fn, cf.localBase)
 				}
-				if cf.Fn == nil {
+				if cf.fn == nil {
 					ls.RaiseError("attempt to call a non-function object")
 				}
 				if ls.stack.sp == ls.Options.CallStackSize {
@@ -616,7 +616,7 @@ func init() {
 					cs := ls.stack
 					v := cf
 					cs.array[cs.sp] = v
-					cs.array[cs.sp].Idx = cs.sp
+					cs.array[cs.sp].idx = cs.sp
 					cs.sp++
 				}
 				newcf := ls.stack.Last()
@@ -624,14 +624,14 @@ func init() {
 				// source function is 'func (ls *LState) initCallFrame(cf *callFrame) ' in '_state.go'
 				{
 					cf := newcf
-					if cf.Fn.IsG {
-						ls.reg.SetTop(cf.LocalBase + cf.NArgs)
+					if cf.fn.IsG {
+						ls.reg.SetTop(cf.localBase + cf.nArgs)
 					} else {
-						proto := cf.Fn.Proto
-						nargs := cf.NArgs
+						proto := cf.fn.Proto
+						nargs := cf.nArgs
 						np := int(proto.NumParameters)
 						for i := nargs; i < np; i++ {
-							ls.reg.array[cf.LocalBase+i] = LNil
+							ls.reg.array[cf.localBase+i] = LNil
 							nargs = np
 						}
 
@@ -640,9 +640,9 @@ func init() {
 								nargs = int(proto.NumUsedRegisters)
 							}
 							for i := np; i < nargs; i++ {
-								ls.reg.array[cf.LocalBase+i] = LNil
+								ls.reg.array[cf.localBase+i] = LNil
 							}
-							ls.reg.top = cf.LocalBase + int(proto.NumUsedRegisters)
+							ls.reg.top = cf.localBase + int(proto.NumUsedRegisters)
 						} else {
 							/* swap vararg positions:
 									   closure
@@ -666,30 +666,30 @@ func init() {
 								nvarargs = 0
 							}
 
-							ls.reg.SetTop(cf.LocalBase + nargs + np)
+							ls.reg.SetTop(cf.localBase + nargs + np)
 							for i := 0; i < np; i++ {
-								//ls.reg.Set(cf.LocalBase+nargs+i, ls.reg.Get(cf.LocalBase+i))
-								ls.reg.array[cf.LocalBase+nargs+i] = ls.reg.array[cf.LocalBase+i]
-								//ls.reg.Set(cf.LocalBase+i, LNil)
-								ls.reg.array[cf.LocalBase+i] = LNil
+								//ls.reg.Set(cf.localBase+nargs+i, ls.reg.Get(cf.localBase+i))
+								ls.reg.array[cf.localBase+nargs+i] = ls.reg.array[cf.localBase+i]
+								//ls.reg.Set(cf.localBase+i, LNil)
+								ls.reg.array[cf.localBase+i] = LNil
 							}
 
 							if CompatVarArg {
-								ls.reg.SetTop(cf.LocalBase + nargs + np + 1)
+								ls.reg.SetTop(cf.localBase + nargs + np + 1)
 								if (proto.IsVarArg & VarArgNeedsArg) != 0 {
 									argtb := newLTable(nvarargs, 0)
 									for i := 0; i < nvarargs; i++ {
-										argtb.RawSetInt(i+1, ls.reg.Get(cf.LocalBase+np+i))
+										argtb.RawSetInt(i+1, ls.reg.Get(cf.localBase+np+i))
 									}
 									argtb.RawSetString("n", LNumber(nvarargs))
-									//ls.reg.Set(cf.LocalBase+nargs+np, argtb)
-									ls.reg.array[cf.LocalBase+nargs+np] = argtb
+									//ls.reg.Set(cf.localBase+nargs+np, argtb)
+									ls.reg.array[cf.localBase+nargs+np] = argtb
 								} else {
-									ls.reg.array[cf.LocalBase+nargs+np] = LNil
+									ls.reg.array[cf.localBase+nargs+np] = LNil
 								}
 							}
-							cf.LocalBase += nargs
-							maxreg := cf.LocalBase + int(proto.NumUsedRegisters)
+							cf.localBase += nargs
+							maxreg := cf.localBase + int(proto.NumUsedRegisters)
 							ls.reg.SetTop(maxreg)
 						}
 					}
@@ -704,7 +704,7 @@ func init() {
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_TAILCALL
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			B := int(inst & 0x1ff) //GETB
@@ -747,49 +747,49 @@ func init() {
 			if callable.IsG {
 				luaframe := cf
 				L.pushCallFrame(callFrame{
-					Fn:         callable,
-					Pc:         0,
-					Base:       RA,
-					LocalBase:  RA + 1,
-					ReturnBase: cf.ReturnBase,
-					NArgs:      nargs,
-					NRet:       cf.NRet,
-					Parent:     cf,
-					TailCall:   0,
+					fn:         callable,
+					pc:         0,
+					base:       RA,
+					localBase:  RA + 1,
+					returnBase: cf.returnBase,
+					nArgs:      nargs,
+					nRet:       cf.nRet,
+					parent:     cf,
+					tailCall:   0,
 				}, lv, meta)
 				if callGFunction(L, true) {
 					return 1
 				}
-				if L.currentFrame == nil || L.currentFrame.Fn.IsG || luaframe == baseframe {
+				if L.currentFrame == nil || L.currentFrame.fn.IsG || luaframe == baseframe {
 					return 1
 				}
 			} else {
-				base := cf.Base
-				cf.Fn = callable
-				cf.Pc = 0
-				cf.Base = RA
-				cf.LocalBase = RA + 1
-				cf.ReturnBase = cf.ReturnBase
-				cf.NArgs = nargs
-				cf.NRet = cf.NRet
-				cf.TailCall++
-				lbase := cf.LocalBase
+				base := cf.base
+				cf.fn = callable
+				cf.pc = 0
+				cf.base = RA
+				cf.localBase = RA + 1
+				cf.returnBase = cf.returnBase
+				cf.nArgs = nargs
+				cf.nRet = cf.nRet
+				cf.tailCall++
+				lbase := cf.localBase
 				if meta {
-					cf.NArgs++
-					L.reg.Insert(lv, cf.LocalBase)
+					cf.nArgs++
+					L.reg.Insert(lv, cf.localBase)
 				}
 				// this section is inlined by go-inline
 				// source function is 'func (ls *LState) initCallFrame(cf *callFrame) ' in '_state.go'
 				{
 					ls := L
-					if cf.Fn.IsG {
-						ls.reg.SetTop(cf.LocalBase + cf.NArgs)
+					if cf.fn.IsG {
+						ls.reg.SetTop(cf.localBase + cf.nArgs)
 					} else {
-						proto := cf.Fn.Proto
-						nargs := cf.NArgs
+						proto := cf.fn.Proto
+						nargs := cf.nArgs
 						np := int(proto.NumParameters)
 						for i := nargs; i < np; i++ {
-							ls.reg.array[cf.LocalBase+i] = LNil
+							ls.reg.array[cf.localBase+i] = LNil
 							nargs = np
 						}
 
@@ -798,9 +798,9 @@ func init() {
 								nargs = int(proto.NumUsedRegisters)
 							}
 							for i := np; i < nargs; i++ {
-								ls.reg.array[cf.LocalBase+i] = LNil
+								ls.reg.array[cf.localBase+i] = LNil
 							}
-							ls.reg.top = cf.LocalBase + int(proto.NumUsedRegisters)
+							ls.reg.top = cf.localBase + int(proto.NumUsedRegisters)
 						} else {
 							/* swap vararg positions:
 									   closure
@@ -824,30 +824,30 @@ func init() {
 								nvarargs = 0
 							}
 
-							ls.reg.SetTop(cf.LocalBase + nargs + np)
+							ls.reg.SetTop(cf.localBase + nargs + np)
 							for i := 0; i < np; i++ {
-								//ls.reg.Set(cf.LocalBase+nargs+i, ls.reg.Get(cf.LocalBase+i))
-								ls.reg.array[cf.LocalBase+nargs+i] = ls.reg.array[cf.LocalBase+i]
-								//ls.reg.Set(cf.LocalBase+i, LNil)
-								ls.reg.array[cf.LocalBase+i] = LNil
+								//ls.reg.Set(cf.localBase+nargs+i, ls.reg.Get(cf.localBase+i))
+								ls.reg.array[cf.localBase+nargs+i] = ls.reg.array[cf.localBase+i]
+								//ls.reg.Set(cf.localBase+i, LNil)
+								ls.reg.array[cf.localBase+i] = LNil
 							}
 
 							if CompatVarArg {
-								ls.reg.SetTop(cf.LocalBase + nargs + np + 1)
+								ls.reg.SetTop(cf.localBase + nargs + np + 1)
 								if (proto.IsVarArg & VarArgNeedsArg) != 0 {
 									argtb := newLTable(nvarargs, 0)
 									for i := 0; i < nvarargs; i++ {
-										argtb.RawSetInt(i+1, ls.reg.Get(cf.LocalBase+np+i))
+										argtb.RawSetInt(i+1, ls.reg.Get(cf.localBase+np+i))
 									}
 									argtb.RawSetString("n", LNumber(nvarargs))
-									//ls.reg.Set(cf.LocalBase+nargs+np, argtb)
-									ls.reg.array[cf.LocalBase+nargs+np] = argtb
+									//ls.reg.Set(cf.localBase+nargs+np, argtb)
+									ls.reg.array[cf.localBase+nargs+np] = argtb
 								} else {
-									ls.reg.array[cf.LocalBase+nargs+np] = LNil
+									ls.reg.array[cf.localBase+nargs+np] = LNil
 								}
 							}
-							cf.LocalBase += nargs
-							maxreg := cf.LocalBase + int(proto.NumUsedRegisters)
+							cf.localBase += nargs
+							maxreg := cf.localBase + int(proto.NumUsedRegisters)
 							ls.reg.SetTop(maxreg)
 						}
 					}
@@ -869,15 +869,15 @@ func init() {
 					}
 					rg.top = regv + n
 				}
-				cf.Base = base
-				cf.LocalBase = base + (cf.LocalBase - lbase + 1)
+				cf.base = base
+				cf.localBase = base + (cf.localBase - lbase + 1)
 			}
 			return 0
 		},
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_RETURN
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			B := int(inst & 0x1ff) //GETB
@@ -905,8 +905,8 @@ func init() {
 			if B == 0 {
 				nret = reg.Top() - RA
 			}
-			n := cf.NRet
-			if cf.NRet == MultRet {
+			n := cf.nRet
+			if cf.nRet == MultRet {
 				n = nret
 			}
 
@@ -952,7 +952,7 @@ func init() {
 			// this section is inlined by go-inline
 			// source function is 'func copyReturnValues(L *LState, regv, start, n, b int) ' in '_vm.go'
 			{
-				regv := cf.ReturnBase
+				regv := cf.returnBase
 				start := RA
 				b := B
 				if b == 1 {
@@ -984,7 +984,7 @@ func init() {
 				}
 			}
 			L.currentFrame = L.stack.Last()
-			if islast || L.currentFrame == nil || L.currentFrame.Fn.IsG {
+			if islast || L.currentFrame == nil || L.currentFrame.fn.IsG {
 				return 1
 			}
 			return 0
@@ -992,7 +992,7 @@ func init() {
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_FORLOOP
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			if init, ok1 := reg.Get(RA).assertFloat64(); ok1 {
@@ -1002,7 +1002,7 @@ func init() {
 						reg.SetNumber(RA, LNumber(init))
 						if (step > 0 && init <= limit) || (step <= 0 && init >= limit) {
 							Sbx := int(inst&0x3ffff) - opMaxArgSbx //GETSBX
-							cf.Pc += Sbx
+							cf.pc += Sbx
 							reg.SetNumber(RA+3, LNumber(init))
 						} else {
 							reg.SetTop(RA + 1)
@@ -1021,7 +1021,7 @@ func init() {
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_FORPREP
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			Sbx := int(inst&0x3ffff) - opMaxArgSbx //GETSBX
@@ -1034,13 +1034,13 @@ func init() {
 			} else {
 				L.RaiseError("for statement init must be a number")
 			}
-			cf.Pc += Sbx
+			cf.pc += Sbx
 			return 0
 		},
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_TFORLOOP
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			C := int(inst>>9) & 0x1ff //GETC
@@ -1052,23 +1052,23 @@ func init() {
 			L.callR(2, nret, RA+3)
 			if value := reg.Get(RA + 3); value != LNil {
 				reg.Set(RA+2, value)
-				pc := cf.Fn.Proto.Code[cf.Pc]
-				cf.Pc += int(pc&0x3ffff) - opMaxArgSbx
+				pc := cf.fn.Proto.Code[cf.pc]
+				cf.pc += int(pc&0x3ffff) - opMaxArgSbx
 			}
-			cf.Pc++
+			cf.pc++
 			return 0
 		},
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_SETLIST
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			B := int(inst & 0x1ff)    //GETB
 			C := int(inst>>9) & 0x1ff //GETC
 			if C == 0 {
-				C = int(cf.Fn.Proto.Code[cf.Pc])
-				cf.Pc++
+				C = int(cf.fn.Proto.Code[cf.pc])
+				cf.pc++
 			}
 			offset := (C - 1) * FieldsPerFlush
 			table := reg.Get(RA).(*LTable)
@@ -1083,7 +1083,7 @@ func init() {
 		},
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_CLOSE
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			// this section is inlined by go-inline
@@ -1111,22 +1111,22 @@ func init() {
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_CLOSURE
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			Bx := int(inst & 0x3ffff) //GETBX
-			proto := cf.Fn.Proto.FunctionPrototypes[Bx]
-			closure := newLFunctionL(proto, cf.Fn.Env, int(proto.NumUpvalues))
+			proto := cf.fn.Proto.FunctionPrototypes[Bx]
+			closure := newLFunctionL(proto, cf.fn.Env, int(proto.NumUpvalues))
 			reg.Set(RA, closure)
 			for i := 0; i < int(proto.NumUpvalues); i++ {
-				inst = cf.Fn.Proto.Code[cf.Pc]
-				cf.Pc++
+				inst = cf.fn.Proto.Code[cf.pc]
+				cf.pc++
 				B := opGetArgB(inst)
 				switch opGetOpCode(inst) {
 				case op_MOVE:
 					closure.Upvalues[i] = L.findUpvalue(lbase + B)
 				case op_GETUPVAL:
-					closure.Upvalues[i] = cf.Fn.Upvalues[B]
+					closure.Upvalues[i] = cf.fn.Upvalues[B]
 				}
 			}
 			return 0
@@ -1134,12 +1134,12 @@ func init() {
 		func(L *LState, inst uint32, baseframe *callFrame) int { //op_VARARG
 			reg := L.reg
 			cf := L.currentFrame
-			lbase := cf.LocalBase
+			lbase := cf.localBase
 			A := int(inst>>18) & 0xff //GETA
 			RA := lbase + A
 			B := int(inst & 0x1ff) //GETB
-			nparams := int(cf.Fn.Proto.NumParameters)
-			nvarargs := cf.NArgs - nparams
+			nparams := int(cf.fn.Proto.NumParameters)
+			nvarargs := cf.nArgs - nparams
 			if nvarargs < 0 {
 				nvarargs = 0
 			}
@@ -1152,8 +1152,8 @@ func init() {
 			{
 				rg := reg
 				regv := RA
-				start := cf.Base + nparams + 1
-				limit := cf.LocalBase
+				start := cf.base + nparams + 1
+				limit := cf.localBase
 				n := nwant
 				for i := 0; i < n; i++ {
 					if tidx := start + i; tidx >= rg.top || limit > -1 && tidx >= limit || tidx < 0 {
@@ -1175,7 +1175,7 @@ func init() {
 func opArith(L *LState, inst uint32, baseframe *callFrame) int { //op_ADD, op_SUB, op_MUL, op_DIV, op_MOD, op_POW
 	reg := L.reg
 	cf := L.currentFrame
-	lbase := cf.LocalBase
+	lbase := cf.localBase
 	A := int(inst>>18) & 0xff //GETA
 	RA := lbase + A
 	opcode := int(inst >> 26) //GETOPCODE


### PR DESCRIPTION
Changes proposed in this pull request:

- replacing and cleaning the fields and constants which are in unexported structs, or are only used for internal namespace.
    - 9bf62b9 opcode.go: unexport opcode constants
    - 0d3d1e4 type CompileError: unexport context - funcContext is unexported
    - 928e92c compile.go: unexport fields in codeBlock, funcContext
    - b8b16ae compile.go: unexport fields in varNamePoolValue
    - 7438224 compile.go: add comment for Value in constValueExpr
    - 044e437 opcode.go: unexport fields in opProp
    - 71264c1 pm.go: unexport fields in scannerState, scanner
    - 735b8af pm.go: unexport fields in inst
    - 8a8fe4c pm.go: unexport fields in unexported structs
    - 124ef63 state.go: unexport fields in callFrame
    - 5ddcf15 utils.go: unexport fields in flagScanner
    - e0f35fc stringlib.go: unexport fields in replaceInfo
- minor changes for readability of code
    - 47b34d0 channellib.go: use named field to compose literal
    - 35aa627 readBufio*: reorder return; remove redundant conditions
    - ed5dbe5 utils.go: refactor logic flow of flagScanner.Next & parseNumber