### PR TITLE
type CompileError: unexport context - funcContext is unexported

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -134,7 +134,7 @@ type CompileError struct { // {{{
 }
 
 func (e *CompileError) Error() string {
-	return fmt.Sprintf("compile error near line(%v) %v: %v", e.Line, e.context.proto.SourceName, e.Message)
+	return fmt.Sprintf("compile error near line(%v) %v: %v", e.Line, e.context.Proto.SourceName, e.Message)
 } // }}}
 
 type codeStore struct { // {{{

--- a/compile.go
+++ b/compile.go
@@ -99,7 +99,7 @@ func savereg(ec *expcontext, reg int) int {
 
 func raiseCompileError(context *funcContext, line int, format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
-	panic(&CompileError{Context: context, Line: line, Message: msg})
+	panic(&CompileError{context: context, Line: line, Message: msg})
 }
 
 func isVarArgReturnExpr(expr ast.Expr) bool {
@@ -128,13 +128,13 @@ func lnumberValue(expr ast.Expr) (LNumber, bool) {
 /* utilities }}} */
 
 type CompileError struct { // {{{
-	Context *funcContext
+	context *funcContext
 	Line    int
 	Message string
 }
 
 func (e *CompileError) Error() string {
-	return fmt.Sprintf("compile error near line(%v) %v: %v", e.Line, e.Context.Proto.SourceName, e.Message)
+	return fmt.Sprintf("compile error near line(%v) %v: %v", e.Line, e.context.proto.SourceName, e.Message)
 } // }}}
 
 type codeStore struct { // {{{


### PR DESCRIPTION
Cherry-picked from commit 0d3d1e4 pull request #97

For more detail, see https://github.com/yuin/gopher-lua/pull/97#issuecomment-277181282