### PR TITLE
Issue #120 : safe unsafeFastStringToReadOnlyBytes.

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -4,11 +4,9 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"reflect"
 	"strconv"
 	"strings"
 	"time"
-	"unsafe"
 )
 
 func intMin(a, b int) int {
@@ -253,10 +251,4 @@ func strCmp(s1, s2 string) int {
 			return 0
 		}
 	}
-}
-
-func unsafeFastStringToReadOnlyBytes(s string) []byte {
-	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	bh := reflect.SliceHeader{sh.Data, sh.Len, sh.Len}
-	return *(*[]byte)(unsafe.Pointer(&bh))
 }

--- a/utils_safe.go
+++ b/utils_safe.go
@@ -1,0 +1,7 @@
+// +build js appengine safe
+
+package lua
+
+func unsafeFastStringToReadOnlyBytes(s string) []byte {
+	return []byte(s)
+}

--- a/utils_unsafe.go
+++ b/utils_unsafe.go
@@ -1,0 +1,14 @@
+// +build !js,!appengine,!safe
+
+package lua
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+func unsafeFastStringToReadOnlyBytes(s string) []byte {
+	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	bh := reflect.SliceHeader{sh.Data, sh.Len, sh.Len}
+	return *(*[]byte)(unsafe.Pointer(&bh))
+}


### PR DESCRIPTION
Fixes #120.

Changes proposed in this pull request:

- provide a safe version of `unsafeFastStringToReadOnlyBytes` to be used when compiling code for environments that don't support the "unsafe" package.
