### PR TITLE
Implements support for string.dump and loadstring of binary blob

### DIFF
--- a/_glua-tests/strings.lua
+++ b/_glua-tests/strings.lua
@@ -1,8 +1,9 @@
+local function test_dump(a, b)
+  return a + b
+end
+local new_func = loadstring(string.dump(test_dump))
+assert(new_func(1,2) == test_dump(1,2))
 
-local ok, msg = pcall(function()
-  string.dump()
-end)
-assert(not ok and string.find(msg, "GopherLua does not support the string.dump"))
 assert(string.find("","aaa") == nil)
 assert(string.gsub("hello world", "(%w+)", "%1 %1 %c") == "hello hello %c world world %c")
 local ok, msg = pcall(function()

--- a/dump.go
+++ b/dump.go
@@ -2,7 +2,7 @@ package lua
 
 import (
 	"encoding/binary"
-	"fmt"
+	"errors"
 	"io"
 )
 
@@ -116,7 +116,7 @@ func (d *dumpState) writeString(s string) {
 		d.write(uint32(size))
 		break
 	default:
-		panic(fmt.Sprintf("unsupported pointer size (%d)"))
+		d.err = errors.New("unsupported pointer size")
 	}
 
 	if size > 0 {
@@ -211,7 +211,6 @@ func (l *LState) Dump(w io.Writer) error {
 	fp := fn.Proto
 
 	if err := l.dump(fp, w); err != nil {
-		fmt.Println("An error occured.", err)
 		return err
 	}
 

--- a/dump.go
+++ b/dump.go
@@ -161,6 +161,19 @@ func (d *dumpState) writeDebug(p *FunctionProto) {
 			d.writeString(upval)
 		}
 	}
+
+	/* GopherLua specific */
+	if length = uint32(len(p.DbgCalls)); d.strip {
+		length = 0
+	}
+	d.writeInt(length)
+
+	if d.strip == false {
+		for _, dc := range p.DbgCalls {
+			d.writeString(dc.Name)
+			d.writeInt(uint32(dc.Pc))
+		}
+	}
 }
 
 func (d *dumpState) dumpFunction(p *FunctionProto) {

--- a/dump.go
+++ b/dump.go
@@ -1,0 +1,206 @@
+package lua
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+const Signature = "\033GoL"
+const (
+	VersionMajor = 5
+	VersionMinor = 1
+)
+
+var header struct {
+	Signature                            [4]byte
+	Version, Format, Endianness, IntSize byte
+	PointerSize, InstructionSize         byte
+	NumberSize, IntegralNumber           byte
+}
+
+type dumpState struct {
+	l     *LState
+	out   io.Writer
+	order binary.ByteOrder
+	strip bool
+	err   error
+}
+
+func init() {
+	copy(header.Signature[:], Signature)
+	header.Version = VersionMajor<<4 | VersionMinor
+	header.Format = 0
+	header.Endianness = 1 // binary.LittleEndian
+	header.IntSize = 4
+	header.PointerSize = byte(1+^uintptr(0)>>32&1) * 4
+	header.InstructionSize = byte(1+^uint32(0)>>32&1) * 4
+	header.NumberSize = 8
+	header.IntegralNumber = 0
+}
+
+func (d *dumpState) write(data interface{}) {
+	if d.err == nil {
+		d.err = binary.Write(d.out, d.order, data)
+	}
+}
+
+func (d *dumpState) writeInt(i uint32) {
+	d.write(uint32(i))
+}
+
+func (d *dumpState) writeCode(p *FunctionProto) {
+	d.writeInt(uint32(len(p.Code)))
+	for _, code := range p.Code {
+		d.writeInt(code)
+	}
+}
+
+func (d *dumpState) writeByte(b byte) {
+	d.write(b)
+}
+
+func (d *dumpState) writeBool(b bool) {
+	if b {
+		d.writeByte(1)
+	} else {
+		d.writeByte(0)
+	}
+}
+
+func (d *dumpState) writeNumber(f float64) {
+	d.write(f)
+}
+
+func (d *dumpState) writeConstants(p *FunctionProto) {
+	d.writeInt(uint32(len(p.Constants)))
+
+	for _, constant := range p.Constants {
+		cst := byte(constant.Type())
+		d.writeByte(cst)
+
+		switch constant.Type() {
+		case LTNil:
+		case LTBool:
+			d.writeBool(LVAsBool(constant))
+		case LTNumber:
+			f, _ := constant.assertFloat64()
+			d.writeNumber(f)
+		case LTString:
+			s, _ := constant.assertString()
+			d.writeString(s)
+		default:
+			d.l.Panic(d.l)
+		}
+	}
+
+	d.writeInt(uint32(len(p.FunctionPrototypes)))
+
+	for _, fproto := range p.FunctionPrototypes {
+		d.dumpFunction(fproto)
+	}
+}
+
+func (d *dumpState) writeString(s string) {
+	ba := []byte(s)
+	size := len(s)
+	if size > 0 {
+		size++ // Accounts for 0 byte at the end
+	}
+
+	switch header.PointerSize {
+	case 8:
+		d.write(uint64(size))
+		break
+	case 4:
+		d.write(uint32(size))
+		break
+	default:
+		panic(fmt.Sprintf("unsupported pointer size (%d)"))
+	}
+
+	if size > 0 {
+		d.write(ba)
+		d.writeByte(0) // Write the NULL byte at the end
+	}
+}
+
+func (d *dumpState) writeDebug(p *FunctionProto) {
+	var length uint32
+	if length = uint32(len(p.DbgSourcePositions)); d.strip {
+		length = 0
+	}
+	d.writeInt(length)
+
+	if d.strip == false {
+		for _, sp := range p.DbgSourcePositions {
+			d.writeInt(uint32(sp))
+		}
+	}
+
+	if length = uint32(len(p.DbgLocals)); d.strip {
+		length = 0
+	}
+	d.writeInt(length)
+
+	if d.strip == false {
+		for _, lvar := range p.DbgLocals {
+			d.writeString(lvar.Name)
+			d.writeInt(uint32(lvar.StartPc))
+			d.writeInt(uint32(lvar.EndPc))
+		}
+	}
+
+	if length = uint32(len(p.DbgUpvalues)); d.strip {
+		length = 0
+	}
+	d.writeInt(length)
+
+	if d.strip == false {
+		for _, upval := range p.DbgUpvalues {
+			d.writeString(upval)
+		}
+	}
+}
+
+func (d *dumpState) dumpFunction(p *FunctionProto) {
+	if d.strip == false {
+		d.writeString(p.SourceName)
+	} else {
+		d.writeString("")
+	}
+
+	d.writeInt(uint32(p.LineDefined))
+	d.writeInt(uint32(p.LastLineDefined))
+	d.writeByte(p.NumUpvalues)
+	d.writeByte(p.NumParameters)
+	d.writeByte(p.IsVarArg)
+	d.writeByte(p.NumUsedRegisters)
+	d.writeCode(p)
+	d.writeConstants(p)
+	d.writeDebug(p)
+}
+
+func (d *dumpState) dumpHeader() {
+	d.err = binary.Write(d.out, d.order, header)
+}
+
+func (l *LState) dump(p *FunctionProto, w io.Writer) error {
+	d := dumpState{l: l, out: w, order: binary.LittleEndian, strip: false}
+	d.dumpHeader()
+	d.dumpFunction(p)
+
+	return d.err
+}
+
+func (l *LState) Dump(w io.Writer) error {
+	fn := l.CheckFunction(1)
+	fp := fn.Proto
+
+	if err := l.dump(fp, w); err != nil {
+		fmt.Println("An error occured.", err)
+		return err
+	}
+
+	return nil
+}

--- a/script_test.go
+++ b/script_test.go
@@ -1,6 +1,7 @@
 package lua
 
 import (
+	"bytes"
 	"fmt"
 	"github.com/yuin/gopher-lua/parse"
 	"os"
@@ -77,10 +78,57 @@ func testScriptDir(t *testing.T, tests []string, directory string) {
 	}
 }
 
+func testDumpScriptDir(t *testing.T, tests []string, directory string) {
+	if err := os.Chdir(directory); err != nil {
+		t.Error(err)
+	}
+	defer os.Chdir("..")
+	for _, script := range tests {
+		fmt.Printf("testing %s/%s\n", directory, script)
+		LD := NewState(Options{
+			RegistrySize:  1024 * 20,
+			CallStackSize: 1024,
+		})
+		LD.SetMx(maxMemory)
+
+		buf := new(bytes.Buffer)
+
+		if fn, err := LD.LoadFile(script); err != nil {
+			t.Error(err)
+		} else {
+			LD.Push(fn)
+			LD.Dump(buf)
+		}
+
+		L := NewState(Options{
+			RegistrySize:  1024 * 20,
+			CallStackSize: 1024,
+		})
+		L.SetMx(maxMemory)
+		if err := L.DoString(buf.String()); err != nil {
+			t.Error(err)
+		}
+		L.Close()
+
+		LD.Close()
+	}
+}
+
+
 func TestGlua(t *testing.T) {
+	defer os.Unsetenv("_____GLUATEST______")
 	testScriptDir(t, gluaTests, "_glua-tests")
 }
 
 func TestLua(t *testing.T) {
 	testScriptDir(t, luaTests, "_lua5.1-tests")
+}
+
+func TestDumpGlua(t *testing.T) {
+	defer os.Unsetenv("_____GLUATEST______")
+	testDumpScriptDir(t, gluaTests, "_glua-tests")
+}
+
+func TestDumpLua(t *testing.T) {
+	testDumpScriptDir(t, luaTests, "_lua5.1-tests")
 }

--- a/state.go
+++ b/state.go
@@ -1600,10 +1600,10 @@ func (ls *LState) Load(reader io.Reader, name string) (*LFunction, error) {
 
 	b := bufio.NewReader(reader)
 
-	if sbuf, err := b.Peek(4); err != nil {
-		return nil, newApiErrorE(ApiErrorSyntax, err)
-	} else if string(sbuf) == Signature {
-		binary_mode = true
+	if sbuf, err := b.Peek(4); err == nil {
+		if string(sbuf) == Signature {
+			binary_mode = true
+		}
 	}
 
 	if binary_mode {

--- a/state.go
+++ b/state.go
@@ -1606,9 +1606,6 @@ func (ls *LState) Load(reader io.Reader, name string) (*LFunction, error) {
 		binary_mode = true
 	}
 
-	// Return the read byte
-	_ = b.UnreadByte()
-
 	if binary_mode {
 		proto, err := ls.Undump(b, "=?")
 		if err != nil {
@@ -1617,7 +1614,7 @@ func (ls *LState) Load(reader io.Reader, name string) (*LFunction, error) {
 		return newLFunctionL(proto, ls.currentEnv(), 0), nil
 	}
 
-	chunk, err := parse.Parse(reader, name)
+	chunk, err := parse.Parse(b, name)
 	if err != nil {
 		return nil, newApiErrorE(ApiErrorSyntax, err)
 	}
@@ -1625,6 +1622,7 @@ func (ls *LState) Load(reader io.Reader, name string) (*LFunction, error) {
 	if err != nil {
 		return nil, newApiErrorE(ApiErrorSyntax, err)
 	}
+
 	return newLFunctionL(proto, ls.currentEnv(), 0), nil
 }
 

--- a/stringlib.go
+++ b/stringlib.go
@@ -1,9 +1,9 @@
 package lua
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
-
 	"github.com/yuin/gopher-lua/pm"
 )
 
@@ -81,8 +81,11 @@ func strChar(L *LState) int {
 }
 
 func strDump(L *LState) int {
-	L.RaiseError("GopherLua does not support the string.dump")
-	return 0
+	bytes := new(bytes.Buffer)
+	L.Dump(bytes)
+	L.Push(LString(bytes.String()))
+
+	return 1
 }
 
 func strFind(L *LState) int {

--- a/undump.go
+++ b/undump.go
@@ -255,6 +255,22 @@ func (ud *undumpState) readFunction() (p *FunctionProto, errs error) {
 
 	}
 
+	/* GopherLua specific */
+	if numDebugCalls, err := ud.readInt(); err != nil {
+		return
+	} else {
+		p.DbgCalls = make([]DbgCall, numDebugCalls)
+		for i := 0; i < int(numDebugCalls); i++ {
+			name, _ := ud.readString()
+			pc, _ := ud.readInt()
+
+			p.DbgCalls[i] = DbgCall{
+				Name: name,
+				Pc:   int(pc),
+			}
+		}
+	}
+
 	return
 }
 

--- a/undump.go
+++ b/undump.go
@@ -1,0 +1,270 @@
+package lua
+
+import (
+	// "bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+)
+
+type undumpState struct {
+	l     *LState
+	in    io.Reader
+	order binary.ByteOrder
+	err   error
+	name  string
+}
+
+func (ud *undumpState) read(data interface{}) error {
+	return binary.Read(ud.in, ud.order, data)
+}
+
+func (ud *undumpState) readNumber() (f float64, err error) {
+	err = ud.read(&f)
+	return
+}
+
+func (ud *undumpState) readInt() (i uint32, err error) {
+	err = ud.read(&i)
+	return
+}
+
+func (ud *undumpState) readByte() (b byte, err error) {
+	err = ud.read(&b)
+	return
+}
+
+func (ud *undumpState) readBool() (bool, error) {
+	b, err := ud.readByte()
+	return b != 0, err
+}
+
+func (ud *undumpState) readString() (s string, err error) {
+	var size uint64
+	err = ud.read(&size)
+
+	if err != nil || size == 0 {
+		return
+	}
+	ba := make([]byte, size)
+	if err = ud.read(ba); err == nil {
+		s = string(ba[:len(ba)-1])
+	}
+	return
+}
+
+func (ud *undumpState) readCode() (code []uint32, err error) {
+	n, err := ud.readInt()
+	if err != nil || n == 0 {
+		return
+	}
+	code = make([]uint32, n)
+	err = ud.read(code)
+	return
+}
+
+func (ud *undumpState) readConstants() (constants []LValue, err error) {
+	n, err := ud.readInt()
+	if err != nil || n == 0 {
+		return
+	}
+
+	constants = make([]LValue, n)
+
+	for i := 0; i < int(n); i++ {
+		if b, berr := ud.readByte(); berr != nil {
+			err = berr
+			return
+		} else {
+			switch b {
+			case byte(LTNil):
+				constants[i] = LNil
+			case byte(LTBool):
+				if bval, berr := ud.readBool(); berr != nil {
+					err = berr
+					return
+				} else {
+					constants[i] = LBool(bval)
+				}
+			case byte(LTNumber):
+				if nval, berr := ud.readNumber(); berr != nil {
+					err = berr
+					return
+				} else {
+					constants[i] = LNumber(nval)
+				}
+			case byte(LTString):
+				if sval, berr := ud.readString(); berr != nil {
+					err = berr
+					return
+				} else {
+					constants[i] = LString(sval)
+				}
+			default:
+				return
+			}
+		}
+	}
+
+	return
+}
+
+func (ud *undumpState) readHeader() error {
+	hdr := header
+
+	if err := ud.read(&hdr); err != nil {
+		return err
+	} else if hdr == header {
+		return nil
+	} else if string(hdr.Signature[:]) != Signature {
+		return errors.New("input is not a precompiled chunk")
+	} else if hdr.Version != header.Version || hdr.Format != header.Format {
+		return errors.New("version mismatch")
+	}
+
+	return errors.New("incompatible input")
+}
+
+func (ud *undumpState) readFunction() (p *FunctionProto, errs error) {
+	p = newFunctionProto("")
+
+	if p.SourceName, errs = ud.readString(); errs != nil {
+		return
+	}
+
+	if n, err := ud.readInt(); err != nil {
+		errs = err
+		return
+	} else {
+		p.LineDefined = int(n)
+	}
+
+	if n, err := ud.readInt(); err != nil {
+		errs = err
+		return
+	} else {
+		p.LastLineDefined = int(n)
+	}
+
+	if n, err := ud.readByte(); err != nil {
+		errs = err
+		return
+	} else {
+		p.NumUpvalues = n
+	}
+
+	if n, err := ud.readByte(); err != nil {
+		errs = err
+		return
+	} else {
+		p.NumParameters = n
+	}
+
+	if n, err := ud.readByte(); err != nil {
+		errs = err
+		return
+	} else {
+		p.IsVarArg = n
+	}
+
+	if n, err := ud.readByte(); err != nil {
+		errs = err
+		return
+	} else {
+		p.NumUsedRegisters = n
+	}
+
+	if code, err := ud.readCode(); err != nil {
+		errs = err
+		return
+	} else {
+		p.Code = code
+	}
+
+	if constants, err := ud.readConstants(); err != nil {
+		errs = err
+		return
+	} else {
+		p.Constants = constants
+		for _, cons := range p.Constants {
+			if val, iss := cons.assertString(); iss {
+				p.stringConstants = append(p.stringConstants, val)
+			}
+		}
+	}
+
+	numFunctions, err := ud.readInt()
+	if err != nil {
+		return
+	}
+
+	p.FunctionPrototypes = make([]*FunctionProto, numFunctions)
+
+	for i := 0; i < int(numFunctions); i++ {
+		if f, err := ud.readFunction(); err == nil {
+			p.FunctionPrototypes[i] = f
+		} else {
+			fmt.Println("ERRRR", err)
+		}
+	}
+
+	// Read Debug Info
+
+	if numDebug, err := ud.readInt(); err != nil {
+		return
+	} else {
+		p.DbgSourcePositions = make([]int, numDebug)
+		for i := 0; i < int(numDebug); i++ {
+			if dp, err := ud.readInt(); err == nil {
+				p.DbgSourcePositions[i] = int(dp)
+			}
+		}
+	}
+
+	if numDebugLocals, err := ud.readInt(); err != nil {
+		return
+	} else {
+		p.DbgLocals = make([]*DbgLocalInfo, numDebugLocals)
+		for i := 0; i < int(numDebugLocals); i++ {
+			name, _ := ud.readString()
+			startpc, _ := ud.readInt()
+			endpc, _ := ud.readInt()
+
+			p.DbgLocals[i] = &DbgLocalInfo{
+				Name:    name,
+				StartPc: int(startpc),
+				EndPc:   int(endpc),
+			}
+		}
+	}
+
+	if numDbgUpvals, err := ud.readInt(); err != nil {
+		return
+	} else {
+		p.DbgUpvalues = make([]string, numDbgUpvals)
+		for i := 0; i < int(numDbgUpvals); i++ {
+			if uval, err := ud.readString(); err != nil {
+				return
+			} else {
+				p.DbgUpvalues[i] = uval
+			}
+		}
+
+	}
+
+	return
+}
+
+func (l *LState) Undump(in io.Reader, name string) (fp *FunctionProto, err error) {
+	undumpState := undumpState{l: l, in: in, order: binary.LittleEndian}
+
+	if err = undumpState.readHeader(); err != nil {
+		return nil, err
+	}
+	if fp, err = undumpState.readFunction(); err != nil {
+		return nil, err
+	}
+
+	return fp, nil
+}

--- a/undump.go
+++ b/undump.go
@@ -187,10 +187,12 @@ func (ud *undumpState) readFunction() (p *FunctionProto, errs error) {
 		return
 	} else {
 		p.Constants = constants
-		for _, cons := range p.Constants {
-			if val, iss := cons.assertString(); iss {
-				p.stringConstants = append(p.stringConstants, val)
+		for _, clv := range p.Constants {
+			sv := ""
+			if slv, ok := clv.(LString); ok {
+				sv = string(slv)
 			}
+			p.stringConstants = append(p.stringConstants, sv)
 		}
 	}
 

--- a/undump.go
+++ b/undump.go
@@ -1,10 +1,8 @@
 package lua
 
 import (
-	// "bytes"
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"io"
 )
 
@@ -207,7 +205,8 @@ func (ud *undumpState) readFunction() (p *FunctionProto, errs error) {
 		if f, err := ud.readFunction(); err == nil {
 			p.FunctionPrototypes[i] = f
 		} else {
-			fmt.Println("ERRRR", err)
+			errs = err
+			return
 		}
 	}
 
@@ -220,6 +219,9 @@ func (ud *undumpState) readFunction() (p *FunctionProto, errs error) {
 		for i := 0; i < int(numDebug); i++ {
 			if dp, err := ud.readInt(); err == nil {
 				p.DbgSourcePositions[i] = int(dp)
+			} else {
+				errs = err
+				return
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #127

Changes proposed in this pull request:

- Support for "string.dump"
- Support for doing "loadstring" on a compiled "blob" string

Noteworthy things:
- Incompatible with LUA5.1 binary format
- Need to decide on a GopherLua binary header signature
- Need to decide on a GopherLua binary header version
- Need to decide on how to handle LittleEndian/BigEndian
- Allow for the removal of debug data.