### PR TITLE
Fix A Bug With PCall

### DIFF
--- a/_state.go
+++ b/_state.go
@@ -1575,6 +1575,8 @@ func (ls *LState) PCall(nargs, nret int, errfunc *LFunction) (err error) {
 			} else if len(err.(*ApiError).StackTrace) == 0 {
 				err.(*ApiError).StackTrace = ls.stackTrace(0)
 			}
+			ls.stack.SetSp(sp)
+			ls.currentFrame = ls.stack.Last()
 			ls.reg.SetTop(base)
 		}
 		ls.stack.SetSp(sp)

--- a/state.go
+++ b/state.go
@@ -1660,6 +1660,8 @@ func (ls *LState) PCall(nargs, nret int, errfunc *LFunction) (err error) {
 			} else if len(err.(*ApiError).StackTrace) == 0 {
 				err.(*ApiError).StackTrace = ls.stackTrace(0)
 			}
+			ls.stack.SetSp(sp)
+			ls.currentFrame = ls.stack.Last()
 			ls.reg.SetTop(base)
 		}
 		ls.stack.SetSp(sp)


### PR DESCRIPTION
PCall failed to reset the callstack after a failure, which lead to
errors if someone tried to do certain operations (another function call,
return an error, call Get()) within the same function.

This Fixes That