### PR TITLE
Fix a Bug in Pair

### DIFF
--- a/table.go
+++ b/table.go
@@ -353,7 +353,7 @@ func (tb *LTable) Next(key LValue) (LValue, LValue) {
 	}
 
 	if init || key != LNumber(0) {
-		if kv, ok := key.(LNumber); ok && isInteger(kv) && int(kv) >= 0 {
+		if kv, ok := key.(LNumber); ok && isInteger(kv) && int(kv) >= 0 && kv < LNumber(MaxArrayIndex) {
 			index := int(kv)
 			if tb.array != nil {
 				for ; index < len(tb.array); index++ {


### PR DESCRIPTION
when define a big index(> MaxArrayIndex) in lua table,and use pair to foreach this lua talbe ,it will be a dead-loop.

Fixes #132  .


