### PR TITLE
Add support for 0x prefix in tonumber(v)

### DIFF
--- a/_lua5.1-tests/math.lua
+++ b/_lua5.1-tests/math.lua
@@ -51,6 +51,7 @@ assert(tonumber(string.rep('1', 42), 2) + 1 == 2^42)
 assert(tonumber(string.rep('1', 32), 2) + 1 == 2^32)
 assert(tonumber('-fffffFFFFF', 16)-1 == -2^40)
 assert(tonumber('ffffFFFF', 16)+1 == 2^32)
+assert(tonumber('0xF') == 15)
 
 assert(1.1 == 1.+.1)
 print(100.0, 1E2, .01)

--- a/baselib.go
+++ b/baselib.go
@@ -389,6 +389,8 @@ func baseSetMetatable(L *LState) int {
 
 func baseToNumber(L *LState) int {
 	base := L.OptInt(2, 10)
+	noBase := L.Get(2) == LNil
+
 	switch lv := L.CheckAny(1).(type) {
 	case LNumber:
 		L.Push(lv)
@@ -401,6 +403,9 @@ func baseToNumber(L *LState) int {
 				L.Push(LNumber(v))
 			}
 		} else {
+			if noBase && strings.HasPrefix(strings.ToLower(str), "0x") {
+				base, str = 16, str[2:] // Hex number
+			}
 			if v, err := strconv.ParseInt(str, base, LNumberBit); err != nil {
 				L.Push(LNil)
 			} else {


### PR DESCRIPTION
If base is not specified as a parameter, and the string has the prefix
0x (case insensitive), treat the number as base 16 in the lua baselib tonumber
function.


Note: I know very little about Lua other than that the project I use expects tonumber to have this behaviour. I do not know if the project in question has a customized tonumber function, but I assume not.