### PR TITLE
remove unnecessary condition

### DIFF
--- a/vm.go
+++ b/vm.go
@@ -147,10 +147,9 @@ func callGFunction(L *LState, tailcall bool) bool {
 		rg := L.reg
 		regv := frame.ReturnBase
 		start := L.reg.Top() - gfnret
-		limit := -1
 		n := wantret
 		for i := 0; i < n; i++ {
-			if tidx := start + i; tidx >= rg.top || limit > -1 && tidx >= limit || tidx < 0 {
+			if tidx := start + i; tidx >= rg.top || tidx < 0 {
 				rg.array[regv+i] = LNil
 			} else {
 				rg.array[regv+i] = rg.array[tidx]


### PR DESCRIPTION
limit > -1 && tidx >= limit 
is always false.

Fixes # .

Changes proposed in this pull request:

- a
- b
- c
- d
