### PR TITLE
fix issue os.date(*t) sunday's wday==0

### DIFF
--- a/oslib.go
+++ b/oslib.go
@@ -106,7 +106,7 @@ func osDate(L *LState) int {
 			ret.RawSetString("hour", LNumber(t.Hour()))
 			ret.RawSetString("min", LNumber(t.Minute()))
 			ret.RawSetString("sec", LNumber(t.Second()))
-			ret.RawSetString("wday", LNumber(t.Weekday()))
+			ret.RawSetString("wday", LNumber(t.Weekday()+1))
 			// TODO yday & dst
 			ret.RawSetString("yday", LNumber(0))
 			ret.RawSetString("isdst", LFalse)


### PR DESCRIPTION
Fixes # .
https://github.com/yuin/gopher-lua/issues/145

Changes proposed in this pull request:
just plus one to weekday in golang to make it the same as lua spec