### PR TITLE
fix hex string '0x7FFFFFFFFFFFFFFF' ToInt64() value incorrect

### DIFF
--- a/state.go
+++ b/state.go
@@ -1251,7 +1251,7 @@ func (ls *LState) ToInt(n int) int {
 		return int(lv)
 	}
 	if lv, ok := ls.Get(n).(LString); ok {
-		if num, err := parseNumber(string(lv)); err == nil {
+		if num, err := parseInt64(string(lv)); err == nil {
 			return int(num)
 		}
 	}
@@ -1263,8 +1263,8 @@ func (ls *LState) ToInt64(n int) int64 {
 		return int64(lv)
 	}
 	if lv, ok := ls.Get(n).(LString); ok {
-		if num, err := parseNumber(string(lv)); err == nil {
-			return int64(num)
+		if num, err := parseInt64(string(lv)); err == nil {
+			return num
 		}
 	}
 	return 0

--- a/utils.go
+++ b/utils.go
@@ -155,6 +155,21 @@ func parseNumber(number string) (LNumber, error) {
 	return value, nil
 }
 
+func parseInt64(number string) (int64, error) {
+	var value int64
+	number = strings.Trim(number, " \t\n")
+	if v, err := strconv.ParseInt(number, 0, LNumberBit); err != nil {
+		if v2, err2 := strconv.ParseFloat(number, LNumberBit); err2 != nil {
+			return int64(0), err2
+		} else {
+			value = int64(v2)
+		}
+	} else {
+		value = v
+	}
+	return value, nil
+}
+
 func popenArgs(arg string) (string, []string) {
 	cmd := "/bin/sh"
 	args := []string{"-c"}


### PR DESCRIPTION
fix hex string '0x7FFFFFFFFFFFFFFF' ToInt64() value is -0x8000000000000000, The correct value should be 9223372036854775807 (0x7FFFFFFFFFFFFFFF) .

