### PR TITLE
Issue #168 : math.random(upper) now works fine when upper=1

### DIFF
--- a/_glua-tests/issues.lua
+++ b/_glua-tests/issues.lua
@@ -182,3 +182,10 @@ for i in s:gmatch([=[[[][^%s,]*[]]]=]) do
 end
 assert(result[1] == [=[["a"]['b'][9]]=])
 assert(result[2] == [=[["a"]['b'][8]]=])
+
+-- issue 168
+local expected = 1
+
+local result = math.random(1)
+
+assert(result == expected)

--- a/mathlib.go
+++ b/mathlib.go
@@ -189,7 +189,7 @@ func mathRandom(L *LState) int {
 		L.Push(LNumber(rand.Float64()))
 	case 1:
 		n := L.CheckInt(1)
-		L.Push(LNumber(rand.Intn(n-1) + 1))
+		L.Push(LNumber(rand.Intn(n) + 1))
 	default:
 		min := L.CheckInt(1)
 		max := L.CheckInt(2) + 1


### PR DESCRIPTION
Fixes #168.

Changes proposed in this pull request:

- a `math.random` now confoorms lua docs