### PR TITLE
Change LTString to LString in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,7 +130,7 @@ You can test an object type in Go way(type assertion) or using a ``Type()`` valu
        // lv is LString
        fmt.Println(string(str))
    }
-   if lv.Type() != lua.LTString {
+   if lv.Type() != lua.LString {
        panic("string required.")
    }
 


### PR DESCRIPTION
I believe the reference to type LTString was a typo for LString.

Changes proposed in this pull request:

- Change LTString to LString in the README
