### PR TITLE
Fix loop detection preloadLimit for Go Master branch

### DIFF
--- a/alloc.go
+++ b/alloc.go
@@ -11,7 +11,7 @@ type iface struct {
 	word unsafe.Pointer
 }
 
-const preloadLimit LNumber = 128
+const preloadLimit float64 = 128
 
 var _fv float64
 var _uv uintptr
@@ -51,7 +51,7 @@ func newAllocator(size int) *allocator {
 }
 
 func (al *allocator) LNumber2I(v LNumber) LValue {
-	if v >= 0 && v < preloadLimit && float64(v) == float64(int64(v)) {
+	if v >= 0 && float64(v) < preloadLimit && float64(v) == float64(int64(v)) {
 		return al.preloads[int(v)]
 	}
 	if al.top == len(al.nptrs)-1 {


### PR DESCRIPTION
Fixes #182.

Changes proposed in this pull request:

- preloadLimit changed to float64 to prevent error on loop detection on the master branch of Go.
