### PR TITLE
constant fold optimization

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -1073,8 +1073,8 @@ func compileExprWithMVPropagation(context *funcContext, expr ast.Expr, reg *int,
 func constFold(exp ast.Expr) ast.Expr { // {{{
 	switch expr := exp.(type) {
 	case *ast.ArithmeticOpExpr:
-		lvalue, lisconst := lnumberValue(expr.Lhs)
-		rvalue, risconst := lnumberValue(expr.Rhs)
+		lvalue, lisconst := lnumberValue(constFold(expr.Lhs))
+		rvalue, risconst := lnumberValue(constFold(expr.Rhs))
 		if lisconst && risconst {
 			switch expr.Operator {
 			case "+":


### PR DESCRIPTION
In beblow case: https://github.com/yuin/gopher-lua/blob/ca850f594eaafa5468da2bd53b865e4ee55be18b/_lua5.1-tests/calls.lua#L173

should generate below bytecode
```
=======================const========================
0  ==> assert
1  ==> f
2  ==> 9
3  ==> 16
4  ==> 91
=======================codes========================
<0000:L0001> GETGLOBAL | ABx   |    0,    0        | R(0) := Gbl[Kst(0)]
<0001:L0001> GETGLOBAL | ABx   |    1,    1        | R(1) := Gbl[Kst(1)]
<0002:L0001> LOADK     | ABx   |    2,    2        | R(2) := Kst(2)
<0003:L0001> LOADK     | ABx   |    3,    3        | R(3) := Kst(3)
<0004:L0001> CALL      | ABC   |    1,    3,    2  | R(1) ... R(1+2-2) := R(1)(R(1+1) ... R(1+3-1))
<0005:L0001> EQ        | ABC   |    1,    1,  260  | if ((RK(1) == RK(260)) ~= 1) then pc++
<0006:L0001> JMP       | ASBx  |    0,    1        | pc+=1
<0007:L0001> LOADBOOL  | ABC   |    1,    0,    1  | R(1) := (Bool)0; if (1) pc++
<0008:L0001> LOADBOOL  | ABC   |    1,    1,    0  | R(1) := (Bool)1; if (0) pc++
<0009:L0001> CALL      | ABC   |    0,    2,    1  | R(0) ... R(0+1-2) := R(0)(R(0+1) ... R(0+2-1))
<0010:L0000> RETURN    | ABC   |    0,    1,    0  | return R(0) ... R(0+1-2)
```
instead of
```
=======================const========================
0  ==> assert
1  ==> f
2  ==> 9
3  ==> 16
4  ==> 56
5  ==> 10
=======================codes========================
<0000:L0001> GETGLOBAL | ABx   |    0,    0        | R(0) := Gbl[Kst(0)]
<0001:L0001> GETGLOBAL | ABx   |    1,    1        | R(1) := Gbl[Kst(1)]
<0002:L0001> LOADK     | ABx   |    2,    2        | R(2) := Kst(2)
<0003:L0001> LOADK     | ABx   |    3,    3        | R(3) := Kst(3)
<0004:L0001> CALL      | ABC   |    1,    3,    2  | R(1) ... R(1+2-2) := R(1)(R(1+1) ... R(1+3-1))
<0005:L0001> ADD       | ABC   |    2,  260,  258  | R(2) := RK(260) + RK(258)
<0006:L0001> ADD       | ABC   |    2,    2,  259  | R(2) := RK(2) + RK(259)
<0007:L0001> ADD       | ABC   |    2,    2,  261  | R(2) := RK(2) + RK(261)
<0008:L0001> EQ        | ABC   |    1,    1,    2  | if ((RK(1) == RK(2)) ~= 1) then pc++
<0009:L0001> JMP       | ASBx  |    0,    1        | pc+=1
<0010:L0001> LOADBOOL  | ABC   |    1,    0,    1  | R(1) := (Bool)0; if (1) pc++
<0011:L0001> LOADBOOL  | ABC   |    1,    1,    0  | R(1) := (Bool)1; if (0) pc++
<0012:L0001> CALL      | ABC   |    0,    2,    1  | R(0) ... R(0+1-2) := R(0)(R(0+1) ... R(0+2-1))
<0013:L0000> RETURN    | ABC   |    0,    1,    0  | return R(0) ... R(0+1-2)
```