### PR TITLE
Modify the default escape logic to be same lua5.1 behavior.

### DIFF
--- a/parse/lexer.go
+++ b/parse/lexer.go
@@ -237,9 +237,7 @@ func (sc *Scanner) scanEscape(ch int, buf *bytes.Buffer) error {
 			val, _ := strconv.ParseInt(string(bytes), 10, 32)
 			writeChar(buf, int(val))
 		} else {
-			buf.WriteByte('\\')
 			writeChar(buf, ch)
-			return sc.Error(buf.String(), "Invalid escape sequence")
 		}
 	}
 	return nil


### PR DESCRIPTION
Fixes #223 

Changes proposed in this pull request:

- Modify the default escape logic to be same lua5.1 behavior.
