### PR TITLE
Auto growing stack and registry

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -178,26 +178,56 @@ performance and debugging, but there are some limitations.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Callstack & Registry size
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Size of the callstack & registry is **fixed** for mainly performance.
-You can change the default size of the callstack & registry.
+The size of an ``LState``'s callstack controls the maximum call depth for Lua functions within a script (Go function calls do not count).
 
-.. code-block:: go
+The registry of an ``LState`` implements stack storage for calling functions (both Lua and Go functions) and also for temporary variables in expressions. Its storage requirements will increase with callstack usage and also with code complexity.
 
-   lua.RegistrySize = 1024 * 20
-   lua.CallStackSize = 1024
-   L := lua.NewState()
-   defer L.Close()
+Both the registry and the callstack can be set to either a fixed size or to auto size.
 
-You can also create an LState object that has the callstack & registry size specified by ``Options`` .
+When you have a large number of ``LStates`` instantiated in a process, it's worth taking the time to tune the registry and callstack options.
+
++++++++++
+Registry
++++++++++
+
+The registry can have an initial size, a maximum size and a step size configured on a per ``LState`` basis. This will allow the registry to grow as needed. It will not shrink again after growing.
 
 .. code-block:: go
 
     L := lua.NewState(lua.Options{
-        CallStackSize: 120,
-        RegistrySize:  120*20,
+       RegistrySize: 1024 * 20,         // this is the initial size of the registry
+       RegistryMaxSize: 1024 * 80,      // this is the maximum size that the registry can grow to. If set to `0` (the default) then the registry will not auto grow
+       RegistryGrowStep: 32,            // this is how much to step up the registry by each time it runs out of space. The default is `32`.
     })
+   defer L.Close()
 
-An LState object that has been created by ``*LState#NewThread()`` inherits the callstack & registry size from the parent LState object.
+A registry which is too small for a given script will ultimately result in a panic. A registry which is too big will waste memory (which can be significant if many ``LStates`` are instantiated).
+Auto growing registries incur a small performance hit at the point they are resized but will not otherwise affect performance.
+
++++++++++
+Callstack
++++++++++
+
+The callstack can operate in two different modes, fixed or auto size.
+A fixed size callstack has the highest performance and has a fixed memory overhead.
+An auto sizing callstack will allocate and release callstack pages on demand which will ensure the minimum amount of memory is in use at any time. The downside is it will incur a small performance impact every time a new page of callframes is allocated.
+By default an ``LState`` will allocate and free callstack frames in pages of 8, so the allocation overhead is not incurred on every function call. It is very likely that the performance impact of an auto resizing callstack will be negligible for most use cases.
+
+.. code-block:: go
+
+    L := lua.NewState(lua.Options{
+        CallStackSize: 120,                 // this is the maximum callstack size of this LState
+        MinimizeStackMemory: true,          // Defaults to `false` if not specified. If set, the callstack will auto grow and shrink as needed up to a max of `CallStackSize`. If not set, the callstack will be fixed at `CallStackSize`.
+    })
+   defer L.Close()
+
+++++++++++++++++
+Option defaults
+++++++++++++++++
+
+The above examples show how to customize the callstack and registry size on a per ``LState`` basis. You can also adjust some defaults for when options are not specified by altering the values of ``lua.RegistrySize``, ``lua.RegistryGrowStep`` and ``lua.CallStackSize``.
+
+An ``LState`` object that has been created by ``*LState#NewThread()`` inherits the callstack & registry size from the parent ``LState`` object.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Miscellaneous lua.NewState options

--- a/_state.go
+++ b/_state.go
@@ -1171,7 +1171,7 @@ func NewState(opts ...Options) *LState {
 		if opts[0].RegistrySize < 128 {
 			opts[0].RegistrySize = RegistrySize
 		}
-		if opts[0].RegistryMaxSize < RegistrySize {
+		if opts[0].RegistryMaxSize < opts[0].RegistrySize {
 			opts[0].RegistryMaxSize = 0 // disable growth if max size is smaller than initial size
 		} else {
 			// if growth enabled, grow step is set

--- a/_state.go
+++ b/_state.go
@@ -136,17 +136,21 @@ type callFrame struct {
 }
 
 // FramesPerSegment should be a power of 2 constant for performance reasons. It will allow the go compiler to change
-// the divs and mods into bitshifts.
+// the divs and mods into bitshifts. Max is 256 due to current use of uint8 to count how many frames in a segment are
+// used.
 const FramesPerSegment = 8
 
 type callFrameStackSegment struct {
 	array [FramesPerSegment]callFrame
-	sp    uint8 // FIXME - it would make sense to move this into the callFrameStack
 }
 type segIdx uint16
 type callFrameStack struct {
 	segments []*callFrameStackSegment
 	segIdx   segIdx
+	// segSp is the number of frames in the current segment which are used. Full 'sp' value is segIdx * FramesPerSegment + segSp.
+	// It points to the next stack slot to use, so 0 means to use the 0th element in the segment, and a value of
+	// FramesPerSegment indicates that the segment is full and cannot accommodate another frame.
+	segSp uint8
 }
 
 var segmentPool sync.Pool
@@ -160,7 +164,6 @@ func newCallFrameStackSegment() *callFrameStackSegment {
 }
 
 func freeCallFrameStackSegment(seg *callFrameStackSegment) {
-	seg.sp = 0
 	segmentPool.Put(seg)
 }
 
@@ -177,20 +180,21 @@ func newCallFrameStack(maxSize int) *callFrameStack {
 }
 
 func (cs *callFrameStack) IsEmpty() bool {
-	return cs.segIdx == 0 && cs.segments[0].sp == 0
+	return cs.segIdx == 0 && cs.segSp == 0
 }
 
 // IsFull returns true if the stack cannot receive any more stack pushes without overflowing
 func (cs *callFrameStack) IsFull() bool {
-	return int(cs.segIdx) == len(cs.segments) && cs.segments[cs.segIdx].sp >= FramesPerSegment
+	return int(cs.segIdx) == len(cs.segments) && cs.segSp >= FramesPerSegment
 }
+
 func (cs *callFrameStack) Clear() {
 	for i := segIdx(1); i <= cs.segIdx; i++ {
 		freeCallFrameStackSegment(cs.segments[i])
 		cs.segments[i] = nil
 	}
 	cs.segIdx = 0
-	cs.segments[0].sp = 0
+	cs.segSp = 0
 }
 
 func (cs *callFrameStack) FreeAll() {
@@ -204,19 +208,20 @@ func (cs *callFrameStack) FreeAll() {
 // invoking this to avoid this.
 func (cs *callFrameStack) Push(v callFrame) { // +inline-start
 	curSeg := cs.segments[cs.segIdx]
-	if curSeg.sp >= FramesPerSegment {
+	if cs.segSp >= FramesPerSegment {
 		// segment full, push new segment if allowed
 		if cs.segIdx < segIdx(len(cs.segments)-1) {
 			curSeg = newCallFrameStackSegment()
 			cs.segIdx++
 			cs.segments[cs.segIdx] = curSeg
+			cs.segSp = 0
 		} else {
 			panic("lua callstack overflow")
 		}
 	}
-	curSeg.array[curSeg.sp] = v
-	curSeg.array[curSeg.sp].Idx = int(curSeg.sp) + FramesPerSegment*int(cs.segIdx)
-	curSeg.sp++
+	curSeg.array[cs.segSp] = v
+	curSeg.array[cs.segSp].Idx = int(cs.segSp) + FramesPerSegment*int(cs.segIdx)
+	cs.segSp++
 } // +inline-end
 
 // RemoveCallerFrame removes the stack frame above the current stack frame. This is useful in tail calls. It returns
@@ -257,7 +262,7 @@ func (cs *callFrameStack) RemoveCallerFrame() *callFrame {
 
 // Sp retrieves the current stack depth, which is the number of frames currently pushed on the stack.
 func (cs *callFrameStack) Sp() int {
-	return int(cs.segments[cs.segIdx].sp) + int(cs.segIdx)*FramesPerSegment
+	return int(cs.segSp) + int(cs.segIdx)*FramesPerSegment
 }
 
 // SetSp can be used to rapidly unwind the stack, freeing all stack frames on the way. It should not be used to
@@ -273,18 +278,20 @@ func (cs *callFrameStack) SetSp(sp int) {
 		cs.segments[cs.segIdx] = nil
 		cs.segIdx--
 	}
-	cs.segments[cs.segIdx].sp = desiredFramesInLastSeg
+	cs.segSp = desiredFramesInLastSeg
 }
 
 func (cs *callFrameStack) Last() *callFrame {
 	curSeg := cs.segments[cs.segIdx]
-	if curSeg.sp == 0 {
+	segSp := cs.segSp
+	if segSp == 0 {
 		if cs.segIdx == 0 {
 			return nil
 		}
 		curSeg = cs.segments[cs.segIdx-1]
+		segSp = FramesPerSegment
 	}
-	return &curSeg.array[curSeg.sp-1]
+	return &curSeg.array[segSp-1]
 }
 
 func (cs *callFrameStack) At(sp int) *callFrame {
@@ -296,7 +303,7 @@ func (cs *callFrameStack) At(sp int) *callFrame {
 // Pop pops off the most recent stack frame and returns it
 func (cs *callFrameStack) Pop() *callFrame {
 	curSeg := cs.segments[cs.segIdx]
-	if curSeg.sp == 0 {
+	if cs.segSp == 0 {
 		if cs.segIdx == 0 {
 			// stack empty
 			return nil
@@ -304,10 +311,11 @@ func (cs *callFrameStack) Pop() *callFrame {
 		freeCallFrameStackSegment(curSeg)
 		cs.segments[cs.segIdx] = nil
 		cs.segIdx--
+		cs.segSp = FramesPerSegment
 		curSeg = cs.segments[cs.segIdx]
 	}
-	curSeg.sp--
-	return &curSeg.array[curSeg.sp]
+	cs.segSp--
+	return &curSeg.array[cs.segSp]
 }
 
 /* }}} */

--- a/_vm.go
+++ b/_vm.go
@@ -99,9 +99,7 @@ func callGFunction(L *LState, tailcall bool) bool {
 	frame := L.currentFrame
 	gfnret := frame.Fn.GFunction(L)
 	if tailcall {
-		//L.stack.Remove(L.stack.Sp() - 2) // remove caller lua function frame
-		//L.currentFrame = L.stack.Last()
-		L.currentFrame = L.stack.RemoveCallerFrame()
+		L.currentFrame = L.RemoveCallerFrame()
 	}
 
 	if gfnret < 0 {

--- a/_vm.go
+++ b/_vm.go
@@ -99,8 +99,9 @@ func callGFunction(L *LState, tailcall bool) bool {
 	frame := L.currentFrame
 	gfnret := frame.Fn.GFunction(L)
 	if tailcall {
-		L.stack.Remove(L.stack.Sp() - 2) // remove caller lua function frame
-		L.currentFrame = L.stack.Last()
+		//L.stack.Remove(L.stack.Sp() - 2) // remove caller lua function frame
+		//L.currentFrame = L.stack.Last()
+		L.currentFrame = L.stack.RemoveCallerFrame()
 	}
 
 	if gfnret < 0 {
@@ -615,9 +616,9 @@ func init() {
 				cf.Pc = 0
 				cf.Base = RA
 				cf.LocalBase = RA + 1
-				// cf.ReturnBase = cf.ReturnBase
+				cf.ReturnBase = cf.ReturnBase
 				cf.NArgs = nargs
-				// cf.NRet = cf.NRet
+				cf.NRet = cf.NRet
 				cf.TailCall++
 				lbase := cf.LocalBase
 				if meta {
@@ -858,6 +859,7 @@ func numberArith(L *LState, opcode int, lhs, rhs LNumber) LNumber {
 		return LNumber(math.Pow(flhs, frhs))
 	}
 	panic("should not reach here")
+	return LNumber(0)
 }
 
 func objectArith(L *LState, opcode int, lhs, rhs LValue) LValue {

--- a/config.go
+++ b/config.go
@@ -7,6 +7,7 @@ import (
 var CompatVarArg = true
 var FieldsPerFlush = 50
 var RegistrySize = 256 * 20
+var RegistryGrowStep = 32
 var CallStackSize = 256
 var MaxTableGetLoop = 100
 var MaxArrayIndex = 67108864

--- a/state.go
+++ b/state.go
@@ -137,6 +137,11 @@ type callFrameStack struct {
 	sp    int
 }
 
+type callFrameStackI interface {
+	Push(v callFrame)
+	Pop() *callFrame
+}
+
 func newCallFrameStack(size int) *callFrameStack {
 	return &callFrameStack{
 		array: make([]callFrame, size),

--- a/state.go
+++ b/state.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -94,6 +95,12 @@ type Options struct {
 	CallStackSize int
 	// Data stack size. This defaults to `lua.RegistrySize`.
 	RegistrySize int
+	// Allow the registry to grow from the registry size specified up to a value of RegistryMaxSize. A value of 0
+	// indicates no growth is permitted.
+	RegistryMaxSize int
+	// If growth is enabled, step up by an additional `RegistryGrowStep` each time to avoid having to resize too often.
+	// This defaults to `lua.RegistryGrowStep`
+	RegistryGrowStep int
 	// Controls whether or not libraries are opened by default
 	SkipOpenLibs bool
 	// Tells whether a Go stacktrace should be included in a Lua stacktrace when panics occur.
@@ -132,104 +139,241 @@ type callFrame struct {
 	TailCall   int
 }
 
+// FramesPerSegment should be a power of 2 constant for performance reasons. It will allow the go compiler to change
+// the divs and mods into bitshifts.
+const FramesPerSegment = 8
+
+type callFrameStackSegment struct {
+	array [FramesPerSegment]callFrame
+	sp    uint8
+}
+type segIdx uint16
 type callFrameStack struct {
-	array []callFrame
-	sp    int
+	segments []*callFrameStackSegment
+	segIdx   segIdx
 }
 
-type callFrameStackI interface {
-	Push(v callFrame)
-	Pop() *callFrame
+var segmentPool sync.Pool
+
+func newCallFrameStackSegment() *callFrameStackSegment {
+	seg := segmentPool.Get()
+	if seg == nil {
+		return &callFrameStackSegment{}
+	}
+	return seg.(*callFrameStackSegment)
 }
 
-func newCallFrameStack(size int) *callFrameStack {
-	return &callFrameStack{
-		array: make([]callFrame, size),
-		sp:    0,
+func freeCallFrameStackSegment(seg *callFrameStackSegment) {
+	seg.sp = 0
+	segmentPool.Put(seg)
+}
+
+// newCallFrameStack allocates a new stack for a lua state, which will auto grow up to a max size of at least maxSize.
+// it will actually grow up to the next segment size multiple after maxSize, where the segment size is dictated by
+// FramesPerSegment.
+func newCallFrameStack(maxSize int) *callFrameStack {
+	cs := &callFrameStack{
+		segments: make([]*callFrameStackSegment, (maxSize+(FramesPerSegment-1))/FramesPerSegment),
+		segIdx:   0,
+	}
+	cs.segments[0] = newCallFrameStackSegment()
+	return cs
+}
+
+func (cs *callFrameStack) IsEmpty() bool {
+	return cs.segIdx == 0 && cs.segments[0].sp == 0
+}
+
+// IsFull returns true if the stack cannot receive any more stack pushes without overflowing
+func (cs *callFrameStack) IsFull() bool {
+	return int(cs.segIdx) == len(cs.segments) && cs.segments[cs.segIdx].sp >= FramesPerSegment
+}
+func (cs *callFrameStack) Clear() {
+	for i := segIdx(1); i <= cs.segIdx; i++ {
+		freeCallFrameStackSegment(cs.segments[i])
+		cs.segments[i] = nil
+	}
+	cs.segIdx = 0
+	cs.segments[0].sp = 0
+}
+
+func (cs *callFrameStack) FreeAll() {
+	for i := segIdx(0); i <= cs.segIdx; i++ {
+		freeCallFrameStackSegment(cs.segments[i])
+		cs.segments[i] = nil
 	}
 }
 
-func (cs *callFrameStack) IsEmpty() bool { return cs.sp == 0 }
-
-func (cs *callFrameStack) Clear() {
-	cs.sp = 0
-}
-
+// Push pushes the passed callFrame onto the stack. it panics if the stack is full, caller should call IsFull() before
+// invoking this to avoid this.
 func (cs *callFrameStack) Push(v callFrame) { // +inline-start
-	cs.array[cs.sp] = v
-	cs.array[cs.sp].Idx = cs.sp
-	cs.sp++
+	curSeg := cs.segments[cs.segIdx]
+	if curSeg.sp >= FramesPerSegment {
+		// segment full, push new segment if allowed
+		if cs.segIdx < segIdx(len(cs.segments)-1) {
+			curSeg = newCallFrameStackSegment()
+			cs.segIdx++
+			cs.segments[cs.segIdx] = curSeg
+		} else {
+			panic("lua callstack overflow")
+		}
+	}
+	curSeg.array[curSeg.sp] = v
+	curSeg.array[curSeg.sp].Idx = int(curSeg.sp) + FramesPerSegment*int(cs.segIdx)
+	curSeg.sp++
 } // +inline-end
 
-func (cs *callFrameStack) Remove(sp int) {
-	psp := sp - 1
-	nsp := sp + 1
-	var pre *callFrame
-	var next *callFrame
-	if psp > 0 {
-		pre = &cs.array[psp]
-	}
-	if nsp < cs.sp {
-		next = &cs.array[nsp]
-	}
-	if next != nil {
-		next.Parent = pre
-	}
-	for i := sp; i+1 < cs.sp; i++ {
-		cs.array[i] = cs.array[i+1]
-		cs.array[i].Idx = i
-		cs.sp = i
-	}
-	cs.sp++
+// RemoveCallerFrame removes the stack frame above the current stack frame. This is useful in tail calls. It returns
+// the new current frame.
+func (cs *callFrameStack) RemoveCallerFrame() *callFrame {
+	sp := cs.Sp()
+	parentFrame := cs.At(sp - 2)
+	currentFrame := cs.At(sp - 1)
+	parentsParentFrame := parentFrame.Parent
+	*parentFrame = *currentFrame
+	parentFrame.Parent = parentsParentFrame
+	parentFrame.Idx = sp - 2
+	cs.Pop()
+	return parentFrame
+	/*
+		sp := cs.Sp() - 2
+		psp := sp - 1
+		nsp := sp + 1
+		var pre *callFrame
+		var next *callFrame
+		if psp > 0 {
+			pre = &cs.array[psp]
+		}
+		if nsp < cs.sp {
+			next = &cs.array[nsp]
+		}
+		if next != nil {
+			next.Parent = pre
+		}
+		for i := sp; i+1 < cs.sp; i++ {
+			cs.array[i] = cs.array[i+1]
+			cs.array[i].Idx = i
+			cs.sp = i
+		}
+		cs.sp++
+	*/
 }
 
+// Sp retrieves the current stack depth, which is the number of frames currently pushed on the stack.
 func (cs *callFrameStack) Sp() int {
-	return cs.sp
+	return int(cs.segments[cs.segIdx].sp) + int(cs.segIdx)*FramesPerSegment
 }
 
+// SetSp can be used to rapidly unwind the stack, freeing all stack frames on the way. It should not be used to
+// allocate new stack space, use Push() for that.
 func (cs *callFrameStack) SetSp(sp int) {
-	cs.sp = sp
+	desiredSegIdx := segIdx(sp / FramesPerSegment)
+	desiredFramesInLastSeg := uint8(sp % FramesPerSegment)
+	for {
+		if cs.segIdx <= desiredSegIdx {
+			break
+		}
+		freeCallFrameStackSegment(cs.segments[cs.segIdx])
+		cs.segments[cs.segIdx] = nil
+		cs.segIdx--
+	}
+	cs.segments[cs.segIdx].sp = desiredFramesInLastSeg
 }
 
 func (cs *callFrameStack) Last() *callFrame {
-	if cs.sp == 0 {
-		return nil
+	curSeg := cs.segments[cs.segIdx]
+	if curSeg.sp == 0 {
+		if cs.segIdx == 0 {
+			return nil
+		}
+		curSeg = cs.segments[cs.segIdx-1]
 	}
-	return &cs.array[cs.sp-1]
+	return &curSeg.array[curSeg.sp-1]
 }
 
 func (cs *callFrameStack) At(sp int) *callFrame {
-	return &cs.array[sp]
+	segIdx := segIdx(sp / FramesPerSegment)
+	frameIdx := uint8(sp % FramesPerSegment)
+	return &cs.segments[segIdx].array[frameIdx]
 }
 
+// Pop pops off the most recent stack frame and returns it
 func (cs *callFrameStack) Pop() *callFrame {
-	cs.sp--
-	return &cs.array[cs.sp]
+	curSeg := cs.segments[cs.segIdx]
+	if curSeg.sp == 0 {
+		if cs.segIdx == 0 {
+			// stack empty
+			return nil
+		}
+		freeCallFrameStackSegment(curSeg)
+		cs.segments[cs.segIdx] = nil
+		cs.segIdx--
+		curSeg = cs.segments[cs.segIdx]
+	}
+	curSeg.sp--
+	return &curSeg.array[curSeg.sp]
 }
 
 /* }}} */
 
 /* registry {{{ */
 
+type registryHandler interface {
+	registryOverflow()
+}
 type registry struct {
-	array []LValue
-	top   int
-	alloc *allocator
+	array   []LValue
+	top     int
+	growBy  int
+	maxSize int
+	alloc   *allocator
+	handler registryHandler
 }
 
-func newRegistry(size int, alloc *allocator) *registry {
-	return &registry{make([]LValue, size), 0, alloc}
+func newRegistry(handler registryHandler, initialSize int, growBy int, maxSize int, alloc *allocator) *registry {
+	return &registry{make([]LValue, initialSize), 0, growBy, maxSize, alloc, handler}
 }
 
+// FIXME inline this
+func (rg *registry) checkSize(requiredSize int) {
+	if requiredSize > cap(rg.array) {
+		rg.resize(requiredSize)
+	}
+}
+func (rg *registry) resize(requiredSize int) {
+	newSize := requiredSize + rg.growBy // give some padding
+	if newSize > rg.maxSize {
+		newSize = rg.maxSize
+	}
+	if newSize < requiredSize {
+		rg.handler.registryOverflow()
+		return
+	}
+	rg.forceResize(newSize)
+}
+func (rg *registry) forceResize(newSize int) {
+	newSlice := make([]LValue, newSize)
+	copy(newSlice, rg.array[:rg.top]) // should we copy the area beyond top? there shouldn't be any valid values there so it shouldn't be necessary.
+	rg.array = newSlice
+}
 func (rg *registry) SetTop(top int) {
+	rg.checkSize(top)
 	oldtop := rg.top
 	rg.top = top
 	for i := oldtop; i < rg.top; i++ {
 		rg.array[i] = LNil
 	}
-	for i := rg.top; i < oldtop; i++ {
-		rg.array[i] = LNil
+	// values beyond top don't need to be valid LValues, so setting them to nil is fine
+	// setting them to nil rather than LNil lets us invoke the golang memclr opto
+	if rg.top < oldtop {
+		nilRange := rg.array[rg.top:oldtop]
+		for i := range nilRange {
+			nilRange[i] = nil
+		}
 	}
+	//for i := rg.top; i < oldtop; i++ {
+	//	rg.array[i] = LNil
+	//}
 }
 
 func (rg *registry) Top() int {
@@ -237,6 +381,7 @@ func (rg *registry) Top() int {
 }
 
 func (rg *registry) Push(v LValue) {
+	rg.checkSize(rg.top + 1)
 	rg.array[rg.top] = v
 	rg.top++
 }
@@ -253,6 +398,7 @@ func (rg *registry) Get(reg int) LValue {
 }
 
 func (rg *registry) CopyRange(regv, start, limit, n int) { // +inline-start
+	rg.checkSize(regv + n)
 	for i := 0; i < n; i++ {
 		if tidx := start + i; tidx >= rg.top || limit > -1 && tidx >= limit || tidx < 0 {
 			rg.array[regv+i] = LNil
@@ -264,6 +410,7 @@ func (rg *registry) CopyRange(regv, start, limit, n int) { // +inline-start
 } // +inline-end
 
 func (rg *registry) FillNil(regm, n int) { // +inline-start
+	rg.checkSize(regm + n)
 	for i := 0; i < n; i++ {
 		rg.array[regm+i] = LNil
 	}
@@ -278,12 +425,14 @@ func (rg *registry) Insert(value LValue, reg int) {
 	}
 	top--
 	for ; top >= reg; top-- {
+		// FIXME consider using copy() here if Insert() is called enough
 		rg.Set(top+1, rg.Get(top))
 	}
 	rg.Set(reg, value)
 }
 
 func (rg *registry) Set(reg int, val LValue) {
+	rg.checkSize(reg + 1)
 	rg.array[reg] = val
 	if reg >= rg.top {
 		rg.top = reg + 1
@@ -291,11 +440,18 @@ func (rg *registry) Set(reg int, val LValue) {
 }
 
 func (rg *registry) SetNumber(reg int, val LNumber) {
+	rg.checkSize(reg + 1)
 	rg.array[reg] = rg.alloc.LNumber2I(val)
 	if reg >= rg.top {
 		rg.top = reg + 1
 	}
-} /* }}} */
+}
+
+func (rg *registry) IsFull() bool {
+	return rg.top >= cap(rg.array)
+}
+
+/* }}} */
 
 /* Global {{{ */
 
@@ -334,7 +490,6 @@ func newLState(options Options) *LState {
 		Options: options,
 
 		stop:         0,
-		reg:          newRegistry(options.RegistrySize, al),
 		stack:        newCallFrameStack(options.CallStackSize),
 		alloc:        al,
 		currentFrame: nil,
@@ -344,6 +499,7 @@ func newLState(options Options) *LState {
 		mainLoop:     mainLoop,
 		ctx:          nil,
 	}
+	ls.reg = newRegistry(ls, options.RegistrySize, options.RegistryGrowStep, options.RegistryMaxSize, al)
 	ls.Env = ls.G.Global
 	return ls
 }
@@ -401,6 +557,10 @@ func (ls *LState) raiseError(level int, format string, args ...interface{}) {
 	}
 	if level > 0 {
 		message = fmt.Sprintf("%v %v", ls.where(level-1, true), message)
+	}
+	if ls.reg.IsFull() {
+		// if the registry is full then it won't be possible to push a value, in this case, force a larger size
+		ls.reg.forceResize(ls.reg.Top() + 1)
 	}
 	ls.reg.Push(LString(message))
 	ls.Panic(ls)
@@ -692,6 +852,7 @@ func (ls *LState) initCallFrame(cf *callFrame) { // +inline-start
 		proto := cf.Fn.Proto
 		nargs := cf.NArgs
 		np := int(proto.NumParameters)
+		ls.reg.checkSize(cf.LocalBase + np)
 		for i := nargs; i < np; i++ {
 			ls.reg.array[cf.LocalBase+i] = LNil
 			nargs = np
@@ -701,6 +862,7 @@ func (ls *LState) initCallFrame(cf *callFrame) { // +inline-start
 			if nargs < int(proto.NumUsedRegisters) {
 				nargs = int(proto.NumUsedRegisters)
 			}
+			ls.reg.checkSize(cf.LocalBase + nargs)
 			for i := np; i < nargs; i++ {
 				ls.reg.array[cf.LocalBase+i] = LNil
 			}
@@ -765,7 +927,7 @@ func (ls *LState) pushCallFrame(cf callFrame, fn LValue, meta bool) { // +inline
 	if cf.Fn == nil {
 		ls.RaiseError("attempt to call a non-function object")
 	}
-	if ls.stack.sp == ls.Options.CallStackSize {
+	if ls.stack.IsFull() {
 		ls.RaiseError("stack overflow")
 	}
 	// this section is inlined by go-inline
@@ -773,9 +935,20 @@ func (ls *LState) pushCallFrame(cf callFrame, fn LValue, meta bool) { // +inline
 	{
 		cs := ls.stack
 		v := cf
-		cs.array[cs.sp] = v
-		cs.array[cs.sp].Idx = cs.sp
-		cs.sp++
+		curSeg := cs.segments[cs.segIdx]
+		if curSeg.sp >= FramesPerSegment {
+			// segment full, push new segment if allowed
+			if cs.segIdx < segIdx(len(cs.segments)-1) {
+				curSeg = newCallFrameStackSegment()
+				cs.segIdx++
+				cs.segments[cs.segIdx] = curSeg
+			} else {
+				panic("lua callstack overflow")
+			}
+		}
+		curSeg.array[curSeg.sp] = v
+		curSeg.array[curSeg.sp].Idx = int(curSeg.sp) + FramesPerSegment*int(cs.segIdx)
+		curSeg.sp++
 	}
 	newcf := ls.stack.Last()
 	// this section is inlined by go-inline
@@ -788,6 +961,7 @@ func (ls *LState) pushCallFrame(cf callFrame, fn LValue, meta bool) { // +inline
 			proto := cf.Fn.Proto
 			nargs := cf.NArgs
 			np := int(proto.NumParameters)
+			ls.reg.checkSize(cf.LocalBase + np)
 			for i := nargs; i < np; i++ {
 				ls.reg.array[cf.LocalBase+i] = LNil
 				nargs = np
@@ -797,6 +971,7 @@ func (ls *LState) pushCallFrame(cf callFrame, fn LValue, meta bool) { // +inline
 				if nargs < int(proto.NumUsedRegisters) {
 					nargs = int(proto.NumUsedRegisters)
 				}
+				ls.reg.checkSize(cf.LocalBase + nargs)
 				for i := np; i < nargs; i++ {
 					ls.reg.array[cf.LocalBase+i] = LNil
 				}
@@ -1030,6 +1205,14 @@ func NewState(opts ...Options) *LState {
 		if opts[0].RegistrySize < 128 {
 			opts[0].RegistrySize = RegistrySize
 		}
+		if opts[0].RegistryMaxSize < RegistrySize {
+			opts[0].RegistryMaxSize = 0 // disable growth if max size is smaller than initial size
+		} else {
+			// if growth enabled, grow step is set
+			if opts[0].RegistryGrowStep < 1 {
+				opts[0].RegistryGrowStep = RegistryGrowStep
+			}
+		}
 		ls = newLState(opts[0])
 		if !opts[0].SkipOpenLibs {
 			ls.OpenLibs()
@@ -1045,6 +1228,8 @@ func (ls *LState) Close() {
 		file.Close()
 		os.Remove(file.Name())
 	}
+	ls.stack.FreeAll()
+	ls.stack = nil
 }
 
 /* registry operations {{{ */
@@ -1144,6 +1329,7 @@ func (ls *LState) Get(idx int) LValue {
 			return LNil
 		}
 	}
+	return LNil
 }
 
 func (ls *LState) Push(value LValue) {
@@ -1316,6 +1502,10 @@ func (ls *LState) ToThread(n int) *LState {
 /* }}} */
 
 /* error & debug operations {{{ */
+
+func (ls *LState) registryOverflow() {
+	ls.RaiseError("registry overflow")
+}
 
 // This function is equivalent to luaL_error( http://www.lua.org/manual/5.1/manual.html#luaL_error ).
 func (ls *LState) RaiseError(format string, args ...interface{}) {

--- a/state.go
+++ b/state.go
@@ -1250,7 +1250,7 @@ func NewState(opts ...Options) *LState {
 		if opts[0].RegistrySize < 128 {
 			opts[0].RegistrySize = RegistrySize
 		}
-		if opts[0].RegistryMaxSize < RegistrySize {
+		if opts[0].RegistryMaxSize < opts[0].RegistrySize {
 			opts[0].RegistryMaxSize = 0 // disable growth if max size is smaller than initial size
 		} else {
 			// if growth enabled, grow step is set

--- a/state.go
+++ b/state.go
@@ -139,6 +139,22 @@ type callFrame struct {
 	TailCall   int
 }
 
+type callFrameStack interface {
+	Push(v callFrame)
+	Pop() *callFrame
+	Last() *callFrame
+
+	SetSp(sp int)
+	Sp() int
+	At(sp int) *callFrame
+
+	IsFull() bool
+	IsEmpty() bool
+
+	FreeAll()
+	RemoveCallerFrame() *callFrame
+}
+
 // FramesPerSegment should be a power of 2 constant for performance reasons. It will allow the go compiler to change
 // the divs and mods into bitshifts. Max is 256 due to current use of uint8 to count how many frames in a segment are
 // used.
@@ -148,12 +164,12 @@ type callFrameStackSegment struct {
 	array [FramesPerSegment]callFrame
 }
 type segIdx uint16
-type callFrameStack struct {
+type autoGrowingCallFrameStack struct {
 	segments []*callFrameStackSegment
 	segIdx   segIdx
 	// segSp is the number of frames in the current segment which are used. Full 'sp' value is segIdx * FramesPerSegment + segSp.
 	// It points to the next stack slot to use, so 0 means to use the 0th element in the segment, and a value of
-	// FramesPerSegment indicates that the segment is full and cannot accommodate another frame,
+	// FramesPerSegment indicates that the segment is full and cannot accommodate another frame.
 	segSp uint8
 }
 
@@ -174,8 +190,8 @@ func freeCallFrameStackSegment(seg *callFrameStackSegment) {
 // newCallFrameStack allocates a new stack for a lua state, which will auto grow up to a max size of at least maxSize.
 // it will actually grow up to the next segment size multiple after maxSize, where the segment size is dictated by
 // FramesPerSegment.
-func newCallFrameStack(maxSize int) *callFrameStack {
-	cs := &callFrameStack{
+func newAutoGrowingCallFrameStack(maxSize int) callFrameStack {
+	cs := &autoGrowingCallFrameStack{
 		segments: make([]*callFrameStackSegment, (maxSize+(FramesPerSegment-1))/FramesPerSegment),
 		segIdx:   0,
 	}
@@ -183,16 +199,16 @@ func newCallFrameStack(maxSize int) *callFrameStack {
 	return cs
 }
 
-func (cs *callFrameStack) IsEmpty() bool {
+func (cs *autoGrowingCallFrameStack) IsEmpty() bool {
 	return cs.segIdx == 0 && cs.segSp == 0
 }
 
 // IsFull returns true if the stack cannot receive any more stack pushes without overflowing
-func (cs *callFrameStack) IsFull() bool {
+func (cs *autoGrowingCallFrameStack) IsFull() bool {
 	return int(cs.segIdx) == len(cs.segments) && cs.segSp >= FramesPerSegment
 }
 
-func (cs *callFrameStack) Clear() {
+func (cs *autoGrowingCallFrameStack) Clear() {
 	for i := segIdx(1); i <= cs.segIdx; i++ {
 		freeCallFrameStackSegment(cs.segments[i])
 		cs.segments[i] = nil
@@ -201,7 +217,7 @@ func (cs *callFrameStack) Clear() {
 	cs.segSp = 0
 }
 
-func (cs *callFrameStack) FreeAll() {
+func (cs *autoGrowingCallFrameStack) FreeAll() {
 	for i := segIdx(0); i <= cs.segIdx; i++ {
 		freeCallFrameStackSegment(cs.segments[i])
 		cs.segments[i] = nil
@@ -210,7 +226,7 @@ func (cs *callFrameStack) FreeAll() {
 
 // Push pushes the passed callFrame onto the stack. it panics if the stack is full, caller should call IsFull() before
 // invoking this to avoid this.
-func (cs *callFrameStack) Push(v callFrame) { // +inline-start
+func (cs *autoGrowingCallFrameStack) Push(v callFrame) {
 	curSeg := cs.segments[cs.segIdx]
 	if cs.segSp >= FramesPerSegment {
 		// segment full, push new segment if allowed
@@ -226,11 +242,11 @@ func (cs *callFrameStack) Push(v callFrame) { // +inline-start
 	curSeg.array[cs.segSp] = v
 	curSeg.array[cs.segSp].Idx = int(cs.segSp) + FramesPerSegment*int(cs.segIdx)
 	cs.segSp++
-} // +inline-end
+}
 
 // RemoveCallerFrame removes the stack frame above the current stack frame. This is useful in tail calls. It returns
 // the new current frame.
-func (cs *callFrameStack) RemoveCallerFrame() *callFrame {
+func (cs *autoGrowingCallFrameStack) RemoveCallerFrame() *callFrame {
 	sp := cs.Sp()
 	parentFrame := cs.At(sp - 2)
 	currentFrame := cs.At(sp - 1)
@@ -265,13 +281,13 @@ func (cs *callFrameStack) RemoveCallerFrame() *callFrame {
 }
 
 // Sp retrieves the current stack depth, which is the number of frames currently pushed on the stack.
-func (cs *callFrameStack) Sp() int {
+func (cs *autoGrowingCallFrameStack) Sp() int {
 	return int(cs.segSp) + int(cs.segIdx)*FramesPerSegment
 }
 
 // SetSp can be used to rapidly unwind the stack, freeing all stack frames on the way. It should not be used to
 // allocate new stack space, use Push() for that.
-func (cs *callFrameStack) SetSp(sp int) {
+func (cs *autoGrowingCallFrameStack) SetSp(sp int) {
 	desiredSegIdx := segIdx(sp / FramesPerSegment)
 	desiredFramesInLastSeg := uint8(sp % FramesPerSegment)
 	for {
@@ -285,7 +301,7 @@ func (cs *callFrameStack) SetSp(sp int) {
 	cs.segSp = desiredFramesInLastSeg
 }
 
-func (cs *callFrameStack) Last() *callFrame {
+func (cs *autoGrowingCallFrameStack) Last() *callFrame {
 	curSeg := cs.segments[cs.segIdx]
 	segSp := cs.segSp
 	if segSp == 0 {
@@ -298,14 +314,14 @@ func (cs *callFrameStack) Last() *callFrame {
 	return &curSeg.array[segSp-1]
 }
 
-func (cs *callFrameStack) At(sp int) *callFrame {
+func (cs *autoGrowingCallFrameStack) At(sp int) *callFrame {
 	segIdx := segIdx(sp / FramesPerSegment)
 	frameIdx := uint8(sp % FramesPerSegment)
 	return &cs.segments[segIdx].array[frameIdx]
 }
 
 // Pop pops off the most recent stack frame and returns it
-func (cs *callFrameStack) Pop() *callFrame {
+func (cs *autoGrowingCallFrameStack) Pop() *callFrame {
 	curSeg := cs.segments[cs.segIdx]
 	if cs.segSp == 0 {
 		if cs.segIdx == 0 {
@@ -498,7 +514,7 @@ func newLState(options Options) *LState {
 		Options: options,
 
 		stop:         0,
-		stack:        newCallFrameStack(options.CallStackSize),
+		stack:        newAutoGrowingCallFrameStack(options.CallStackSize),
 		alloc:        al,
 		currentFrame: nil,
 		wrapped:      false,
@@ -938,27 +954,7 @@ func (ls *LState) pushCallFrame(cf callFrame, fn LValue, meta bool) { // +inline
 	if ls.stack.IsFull() {
 		ls.RaiseError("stack overflow")
 	}
-	// this section is inlined by go-inline
-	// source function is 'func (cs *callFrameStack) Push(v callFrame) ' in '_state.go'
-	{
-		cs := ls.stack
-		v := cf
-		curSeg := cs.segments[cs.segIdx]
-		if cs.segSp >= FramesPerSegment {
-			// segment full, push new segment if allowed
-			if cs.segIdx < segIdx(len(cs.segments)-1) {
-				curSeg = newCallFrameStackSegment()
-				cs.segIdx++
-				cs.segments[cs.segIdx] = curSeg
-				cs.segSp = 0
-			} else {
-				panic("lua callstack overflow")
-			}
-		}
-		curSeg.array[cs.segSp] = v
-		curSeg.array[cs.segSp].Idx = int(cs.segSp) + FramesPerSegment*int(cs.segIdx)
-		cs.segSp++
-	}
+	ls.stack.Push(cf)
 	newcf := ls.stack.Last()
 	// this section is inlined by go-inline
 	// source function is 'func (ls *LState) initCallFrame(cf *callFrame) ' in '_state.go'

--- a/state.go
+++ b/state.go
@@ -152,7 +152,82 @@ type callFrameStack interface {
 	IsEmpty() bool
 
 	FreeAll()
-	RemoveCallerFrame() *callFrame
+}
+
+type fixedCallFrameStack struct {
+	array []callFrame
+	sp    int
+}
+
+func newFixedCallFrameStack(size int) callFrameStack {
+	return &fixedCallFrameStack{
+		array: make([]callFrame, size),
+		sp:    0,
+	}
+}
+
+func (cs *fixedCallFrameStack) IsEmpty() bool { return cs.sp == 0 }
+
+func (cs *fixedCallFrameStack) IsFull() bool { return cs.sp == len(cs.array) }
+
+func (cs *fixedCallFrameStack) Clear() {
+	cs.sp = 0
+}
+
+func (cs *fixedCallFrameStack) Push(v callFrame) {
+	cs.array[cs.sp] = v
+	cs.array[cs.sp].Idx = cs.sp
+	cs.sp++
+}
+
+func (cs *fixedCallFrameStack) Remove(sp int) {
+	psp := sp - 1
+	nsp := sp + 1
+	var pre *callFrame
+	var next *callFrame
+	if psp > 0 {
+		pre = &cs.array[psp]
+	}
+	if nsp < cs.sp {
+		next = &cs.array[nsp]
+	}
+	if next != nil {
+		next.Parent = pre
+	}
+	for i := sp; i+1 < cs.sp; i++ {
+		cs.array[i] = cs.array[i+1]
+		cs.array[i].Idx = i
+		cs.sp = i
+	}
+	cs.sp++
+}
+
+func (cs *fixedCallFrameStack) Sp() int {
+	return cs.sp
+}
+
+func (cs *fixedCallFrameStack) SetSp(sp int) {
+	cs.sp = sp
+}
+
+func (cs *fixedCallFrameStack) Last() *callFrame {
+	if cs.sp == 0 {
+		return nil
+	}
+	return &cs.array[cs.sp-1]
+}
+
+func (cs *fixedCallFrameStack) At(sp int) *callFrame {
+	return &cs.array[sp]
+}
+
+func (cs *fixedCallFrameStack) Pop() *callFrame {
+	cs.sp--
+	return &cs.array[cs.sp]
+}
+
+func (cs *fixedCallFrameStack) FreeAll() {
+	// nothing to do for fixed callframestack
 }
 
 // FramesPerSegment should be a power of 2 constant for performance reasons. It will allow the go compiler to change
@@ -242,42 +317,6 @@ func (cs *autoGrowingCallFrameStack) Push(v callFrame) {
 	curSeg.array[cs.segSp] = v
 	curSeg.array[cs.segSp].Idx = int(cs.segSp) + FramesPerSegment*int(cs.segIdx)
 	cs.segSp++
-}
-
-// RemoveCallerFrame removes the stack frame above the current stack frame. This is useful in tail calls. It returns
-// the new current frame.
-func (cs *autoGrowingCallFrameStack) RemoveCallerFrame() *callFrame {
-	sp := cs.Sp()
-	parentFrame := cs.At(sp - 2)
-	currentFrame := cs.At(sp - 1)
-	parentsParentFrame := parentFrame.Parent
-	*parentFrame = *currentFrame
-	parentFrame.Parent = parentsParentFrame
-	parentFrame.Idx = sp - 2
-	cs.Pop()
-	return parentFrame
-	/*
-		sp := cs.Sp() - 2
-		psp := sp - 1
-		nsp := sp + 1
-		var pre *callFrame
-		var next *callFrame
-		if psp > 0 {
-			pre = &cs.array[psp]
-		}
-		if nsp < cs.sp {
-			next = &cs.array[nsp]
-		}
-		if next != nil {
-			next.Parent = pre
-		}
-		for i := sp; i+1 < cs.sp; i++ {
-			cs.array[i] = cs.array[i+1]
-			cs.array[i].Idx = i
-			cs.sp = i
-		}
-		cs.sp++
-	*/
 }
 
 // Sp retrieves the current stack depth, which is the number of frames currently pushed on the stack.
@@ -513,8 +552,9 @@ func newLState(options Options) *LState {
 		Dead:    false,
 		Options: options,
 
-		stop:         0,
-		stack:        newAutoGrowingCallFrameStack(options.CallStackSize),
+		stop: 0,
+		//stack:        newAutoGrowingCallFrameStack(options.CallStackSize),
+		stack:        newFixedCallFrameStack(options.CallStackSize),
 		alloc:        al,
 		currentFrame: nil,
 		wrapped:      false,
@@ -2066,6 +2106,21 @@ func (ls *LState) ToChannel(n int) chan LValue {
 		return (chan LValue)(lv)
 	}
 	return nil
+}
+
+// RemoveCallerFrame removes the stack frame above the current stack frame. This is useful in tail calls. It returns
+// the new current frame.
+func (ls *LState) RemoveCallerFrame() *callFrame {
+	cs := ls.stack
+	sp := cs.Sp()
+	parentFrame := cs.At(sp - 2)
+	currentFrame := cs.At(sp - 1)
+	parentsParentFrame := parentFrame.Parent
+	*parentFrame = *currentFrame
+	parentFrame.Parent = parentsParentFrame
+	parentFrame.Idx = sp - 2
+	cs.Pop()
+	return parentFrame
 }
 
 /* }}} */

--- a/state.go
+++ b/state.go
@@ -96,7 +96,7 @@ type Options struct {
 	// Data stack size. This defaults to `lua.RegistrySize`.
 	RegistrySize int
 	// Allow the registry to grow from the registry size specified up to a value of RegistryMaxSize. A value of 0
-	// indicates no growth is permitted.
+	// indicates no growth is permitted. The registry will not shrink again after any growth.
 	RegistryMaxSize int
 	// If growth is enabled, step up by an additional `RegistryGrowStep` each time to avoid having to resize too often.
 	// This defaults to `lua.RegistryGrowStep`
@@ -105,6 +105,9 @@ type Options struct {
 	SkipOpenLibs bool
 	// Tells whether a Go stacktrace should be included in a Lua stacktrace when panics occur.
 	IncludeGoStackTrace bool
+	// If `MinimizeStackMemory` is set, the call stack will be automatically grown or shrank up to a limit of
+	// `CallStackSize` in order to minimize memory usage. This does incur a slight performance penalty.
+	MinimizeStackMemory bool
 }
 
 /* }}} */
@@ -552,9 +555,7 @@ func newLState(options Options) *LState {
 		Dead:    false,
 		Options: options,
 
-		stop: 0,
-		//stack:        newAutoGrowingCallFrameStack(options.CallStackSize),
-		stack:        newFixedCallFrameStack(options.CallStackSize),
+		stop:         0,
 		alloc:        al,
 		currentFrame: nil,
 		wrapped:      false,
@@ -562,6 +563,11 @@ func newLState(options Options) *LState {
 		hasErrorFunc: false,
 		mainLoop:     mainLoop,
 		ctx:          nil,
+	}
+	if options.MinimizeStackMemory {
+		ls.stack = newAutoGrowingCallFrameStack(options.CallStackSize)
+	} else {
+		ls.stack = newFixedCallFrameStack(options.CallStackSize)
 	}
 	ls.reg = newRegistry(ls, options.RegistrySize, options.RegistryGrowStep, options.RegistryMaxSize, al)
 	ls.Env = ls.G.Global

--- a/state_test.go
+++ b/state_test.go
@@ -432,15 +432,11 @@ func TestPCallAfterFail(t *testing.T) {
 	errorIfFalse(t, strings.Contains(err.Error(), "A New Error"), "error not propogated correctly")
 }
 
-type callFrameStackI interface {
-	Push(v callFrame)
-	Pop() *callFrame
-}
-
 // test pushing and popping from the callstack using direct calls and via an interface redirect
 func BenchmarkCallFrameStackPushPop(t *testing.B) {
 	//stack := newCallFrameStack(256) // direct calls
-	var stack callFrameStackI = newAutoGrowingCallFrameStack(256) // interface calls
+	//var stack callFrameStackI = newAutoGrowingCallFrameStack(256) // interface calls
+	var stack callFrameStack = newFixedCallFrameStack(256) // interface calls
 
 	t.ResetTimer()
 
@@ -456,7 +452,7 @@ func BenchmarkCallFrameStackPushPop(t *testing.B) {
 }
 
 func BenchmarkCallFrameStackUnwind(t *testing.B) {
-	stack := newAutoGrowingCallFrameStack(256)
+	stack := newFixedCallFrameStack(256)
 
 	t.ResetTimer()
 

--- a/state_test.go
+++ b/state_test.go
@@ -440,7 +440,7 @@ type callFrameStackI interface {
 // test pushing and popping from the callstack using direct calls and via an interface redirect
 func BenchmarkCallFrameStackPushPop(t *testing.B) {
 	//stack := newCallFrameStack(256) // direct calls
-	var stack callFrameStackI = newCallFrameStack(256) // interface calls
+	var stack callFrameStackI = newAutoGrowingCallFrameStack(256) // interface calls
 
 	t.ResetTimer()
 
@@ -456,7 +456,7 @@ func BenchmarkCallFrameStackPushPop(t *testing.B) {
 }
 
 func BenchmarkCallFrameStackUnwind(t *testing.B) {
-	stack := newCallFrameStack(256)
+	stack := newAutoGrowingCallFrameStack(256)
 
 	t.ResetTimer()
 

--- a/state_test.go
+++ b/state_test.go
@@ -448,6 +448,20 @@ func BenchmarkCallFrameStackPushPop(t *testing.B) {
 	}
 }
 
+func BenchmarkCallFrameStackUnwind(t *testing.B) {
+	stack := newCallFrameStack(256)
+
+	t.ResetTimer()
+
+	const Iterations = 256
+	for j := 0; j < t.N; j++ {
+		for i := 0; i < Iterations; i++ {
+			stack.Push(callFrame{})
+		}
+		stack.SetSp(0)
+	}
+}
+
 // test pushing and popping from the registry
 func BenchmarkRegistryPushPop(t *testing.B) {
 	al := newAllocator(32)
@@ -464,5 +478,18 @@ func BenchmarkRegistryPushPop(t *testing.B) {
 		for i := 0; i < sz; i++ {
 			reg.Pop()
 		}
+	}
+}
+
+func BenchmarkRegistrySetTop(t *testing.B) {
+	al := newAllocator(32)
+	sz := 256 * 20
+	reg := newRegistry(sz, al)
+
+	t.ResetTimer()
+
+	for j := 0; j < t.N; j++ {
+		reg.SetTop(sz)
+		reg.SetTop(0)
 	}
 }

--- a/state_test.go
+++ b/state_test.go
@@ -447,3 +447,22 @@ func BenchmarkCallFrameStackPushPop(t *testing.B) {
 		}
 	}
 }
+
+// test pushing and popping from the registry
+func BenchmarkRegistryPushPop(t *testing.B) {
+	al := newAllocator(32)
+	sz := 256 * 20
+	reg := newRegistry(sz, al)
+	value := LString("test")
+
+	t.ResetTimer()
+
+	for j := 0; j < t.N; j++ {
+		for i := 0; i < sz; i++ {
+			reg.Push(value)
+		}
+		for i := 0; i < sz; i++ {
+			reg.Pop()
+		}
+	}
+}

--- a/state_test.go
+++ b/state_test.go
@@ -551,6 +551,39 @@ func BenchmarkCallFrameStackPushPopFixed(t *testing.B) {
 	}
 }
 
+// this test will intentionally not incur stack growth in order to bench the performance when no allocations happen
+func BenchmarkCallFrameStackPushPopShallowAutoGrow(t *testing.B) {
+	stack := newAutoGrowingCallFrameStack(256)
+
+	t.ResetTimer()
+
+	const Iterations = 8
+	for j := 0; j < t.N; j++ {
+		for i := 0; i < Iterations; i++ {
+			stack.Push(callFrame{})
+		}
+		for i := 0; i < Iterations; i++ {
+			stack.Pop()
+		}
+	}
+}
+
+func BenchmarkCallFrameStackPushPopShallowFixed(t *testing.B) {
+	stack := newFixedCallFrameStack(256)
+
+	t.ResetTimer()
+
+	const Iterations = 8
+	for j := 0; j < t.N; j++ {
+		for i := 0; i < Iterations; i++ {
+			stack.Push(callFrame{})
+		}
+		for i := 0; i < Iterations; i++ {
+			stack.Pop()
+		}
+	}
+}
+
 func BenchmarkCallFrameStackPushPopFixedNoInterface(t *testing.B) {
 	stack := newFixedCallFrameStack(256).(*fixedCallFrameStack)
 

--- a/state_test.go
+++ b/state_test.go
@@ -429,3 +429,21 @@ func TestPCallAfterFail(t *testing.T) {
 	err := L.PCall(0, 0, nil)
 	errorIfFalse(t, strings.Contains(err.Error(), "A New Error"), "error not propogated correctly")
 }
+
+// test pushing and popping from the callstack using direct calls and via an interface redirect
+func BenchmarkCallFrameStackPushPop(t *testing.B) {
+	stack := newCallFrameStack(256) // direct calls
+	//var stack callFrameStackI = newCallFrameStack(256)	// interface calls
+
+	t.ResetTimer()
+
+	const Iterations = 256
+	for j := 0; j < t.N; j++ {
+		for i := 0; i < Iterations; i++ {
+			stack.Push(callFrame{})
+		}
+		for i := 0; i < Iterations; i++ {
+			stack.Pop()
+		}
+	}
+}

--- a/value.go
+++ b/value.go
@@ -210,7 +210,7 @@ type LState struct {
 
 	stop         int32
 	reg          *registry
-	stack        *callFrameStack
+	stack        callFrameStack
 	alloc        *allocator
 	currentFrame *callFrame
 	wrapped      bool

--- a/vm.go
+++ b/vm.go
@@ -71,7 +71,15 @@ func copyReturnValues(L *LState, regv, start, n, b int) { // +inline-start
 		{
 			rg := L.reg
 			regm := regv
-			rg.checkSize(regm + n)
+			newSize := regm + n
+			// this section is inlined by go-inline
+			// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+			{
+				requiredSize := newSize
+				if requiredSize > cap(rg.array) {
+					rg.resize(requiredSize)
+				}
+			}
 			for i := 0; i < n; i++ {
 				rg.array[regm+i] = LNil
 			}
@@ -83,7 +91,15 @@ func copyReturnValues(L *LState, regv, start, n, b int) { // +inline-start
 		{
 			rg := L.reg
 			limit := -1
-			rg.checkSize(regv + n)
+			newSize := regv + n
+			// this section is inlined by go-inline
+			// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+			{
+				requiredSize := newSize
+				if requiredSize > cap(rg.array) {
+					rg.resize(requiredSize)
+				}
+			}
 			for i := 0; i < n; i++ {
 				if tidx := start + i; tidx >= rg.top || limit > -1 && tidx >= limit || tidx < 0 {
 					rg.array[regv+i] = LNil
@@ -163,7 +179,15 @@ func callGFunction(L *LState, tailcall bool) bool {
 		start := L.reg.Top() - gfnret
 		limit := -1
 		n := wantret
-		rg.checkSize(regv + n)
+		newSize := regv + n
+		// this section is inlined by go-inline
+		// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+		{
+			requiredSize := newSize
+			if requiredSize > cap(rg.array) {
+				rg.resize(requiredSize)
+			}
+		}
 		for i := 0; i < n; i++ {
 			if tidx := start + i; tidx >= rg.top || limit > -1 && tidx >= limit || tidx < 0 {
 				rg.array[regv+i] = LNil
@@ -642,7 +666,16 @@ func init() {
 						proto := cf.Fn.Proto
 						nargs := cf.NArgs
 						np := int(proto.NumParameters)
-						ls.reg.checkSize(cf.LocalBase + np)
+						newSize := cf.LocalBase + np
+						// this section is inlined by go-inline
+						// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+						{
+							rg := ls.reg
+							requiredSize := newSize
+							if requiredSize > cap(rg.array) {
+								rg.resize(requiredSize)
+							}
+						}
 						for i := nargs; i < np; i++ {
 							ls.reg.array[cf.LocalBase+i] = LNil
 							nargs = np
@@ -652,7 +685,16 @@ func init() {
 							if nargs < int(proto.NumUsedRegisters) {
 								nargs = int(proto.NumUsedRegisters)
 							}
-							ls.reg.checkSize(cf.LocalBase + nargs)
+							newSize = cf.LocalBase + nargs
+							// this section is inlined by go-inline
+							// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+							{
+								rg := ls.reg
+								requiredSize := newSize
+								if requiredSize > cap(rg.array) {
+									rg.resize(requiredSize)
+								}
+							}
 							for i := np; i < nargs; i++ {
 								ls.reg.array[cf.LocalBase+i] = LNil
 							}
@@ -802,7 +844,16 @@ func init() {
 						proto := cf.Fn.Proto
 						nargs := cf.NArgs
 						np := int(proto.NumParameters)
-						ls.reg.checkSize(cf.LocalBase + np)
+						newSize := cf.LocalBase + np
+						// this section is inlined by go-inline
+						// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+						{
+							rg := ls.reg
+							requiredSize := newSize
+							if requiredSize > cap(rg.array) {
+								rg.resize(requiredSize)
+							}
+						}
 						for i := nargs; i < np; i++ {
 							ls.reg.array[cf.LocalBase+i] = LNil
 							nargs = np
@@ -812,7 +863,16 @@ func init() {
 							if nargs < int(proto.NumUsedRegisters) {
 								nargs = int(proto.NumUsedRegisters)
 							}
-							ls.reg.checkSize(cf.LocalBase + nargs)
+							newSize = cf.LocalBase + nargs
+							// this section is inlined by go-inline
+							// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+							{
+								rg := ls.reg
+								requiredSize := newSize
+								if requiredSize > cap(rg.array) {
+									rg.resize(requiredSize)
+								}
+							}
 							for i := np; i < nargs; i++ {
 								ls.reg.array[cf.LocalBase+i] = LNil
 							}
@@ -876,7 +936,15 @@ func init() {
 					start := RA
 					limit := -1
 					n := reg.Top() - RA - 1
-					rg.checkSize(regv + n)
+					newSize := regv + n
+					// this section is inlined by go-inline
+					// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+					{
+						requiredSize := newSize
+						if requiredSize > cap(rg.array) {
+							rg.resize(requiredSize)
+						}
+					}
 					for i := 0; i < n; i++ {
 						if tidx := start + i; tidx >= rg.top || limit > -1 && tidx >= limit || tidx < 0 {
 							rg.array[regv+i] = LNil
@@ -940,7 +1008,15 @@ func init() {
 						{
 							rg := L.reg
 							regm := regv
-							rg.checkSize(regm + n)
+							newSize := regm + n
+							// this section is inlined by go-inline
+							// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+							{
+								requiredSize := newSize
+								if requiredSize > cap(rg.array) {
+									rg.resize(requiredSize)
+								}
+							}
 							for i := 0; i < n; i++ {
 								rg.array[regm+i] = LNil
 							}
@@ -952,7 +1028,15 @@ func init() {
 						{
 							rg := L.reg
 							limit := -1
-							rg.checkSize(regv + n)
+							newSize := regv + n
+							// this section is inlined by go-inline
+							// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+							{
+								requiredSize := newSize
+								if requiredSize > cap(rg.array) {
+									rg.resize(requiredSize)
+								}
+							}
 							for i := 0; i < n; i++ {
 								if tidx := start + i; tidx >= rg.top || limit > -1 && tidx >= limit || tidx < 0 {
 									rg.array[regv+i] = LNil
@@ -993,7 +1077,15 @@ func init() {
 					{
 						rg := L.reg
 						regm := regv
-						rg.checkSize(regm + n)
+						newSize := regm + n
+						// this section is inlined by go-inline
+						// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+						{
+							requiredSize := newSize
+							if requiredSize > cap(rg.array) {
+								rg.resize(requiredSize)
+							}
+						}
 						for i := 0; i < n; i++ {
 							rg.array[regm+i] = LNil
 						}
@@ -1005,7 +1097,15 @@ func init() {
 					{
 						rg := L.reg
 						limit := -1
-						rg.checkSize(regv + n)
+						newSize := regv + n
+						// this section is inlined by go-inline
+						// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+						{
+							requiredSize := newSize
+							if requiredSize > cap(rg.array) {
+								rg.resize(requiredSize)
+							}
+						}
 						for i := 0; i < n; i++ {
 							if tidx := start + i; tidx >= rg.top || limit > -1 && tidx >= limit || tidx < 0 {
 								rg.array[regv+i] = LNil
@@ -1202,7 +1302,15 @@ func init() {
 				start := cf.Base + nparams + 1
 				limit := cf.LocalBase
 				n := nwant
-				rg.checkSize(regv + n)
+				newSize := regv + n
+				// this section is inlined by go-inline
+				// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+				{
+					requiredSize := newSize
+					if requiredSize > cap(rg.array) {
+						rg.resize(requiredSize)
+					}
+				}
 				for i := 0; i < n; i++ {
 					if tidx := start + i; tidx >= rg.top || limit > -1 && tidx >= limit || tidx < 0 {
 						rg.array[regv+i] = LNil

--- a/vm.go
+++ b/vm.go
@@ -632,27 +632,7 @@ func init() {
 				if ls.stack.IsFull() {
 					ls.RaiseError("stack overflow")
 				}
-				// this section is inlined by go-inline
-				// source function is 'func (cs *callFrameStack) Push(v callFrame) ' in '_state.go'
-				{
-					cs := ls.stack
-					v := cf
-					curSeg := cs.segments[cs.segIdx]
-					if cs.segSp >= FramesPerSegment {
-						// segment full, push new segment if allowed
-						if cs.segIdx < segIdx(len(cs.segments)-1) {
-							curSeg = newCallFrameStackSegment()
-							cs.segIdx++
-							cs.segments[cs.segIdx] = curSeg
-							cs.segSp = 0
-						} else {
-							panic("lua callstack overflow")
-						}
-					}
-					curSeg.array[cs.segSp] = v
-					curSeg.array[cs.segSp].Idx = int(cs.segSp) + FramesPerSegment*int(cs.segIdx)
-					cs.segSp++
-				}
+				ls.stack.Push(cf)
 				newcf := ls.stack.Last()
 				// this section is inlined by go-inline
 				// source function is 'func (ls *LState) initCallFrame(cf *callFrame) ' in '_state.go'

--- a/vm.go
+++ b/vm.go
@@ -638,19 +638,20 @@ func init() {
 					cs := ls.stack
 					v := cf
 					curSeg := cs.segments[cs.segIdx]
-					if curSeg.sp >= FramesPerSegment {
+					if cs.segSp >= FramesPerSegment {
 						// segment full, push new segment if allowed
 						if cs.segIdx < segIdx(len(cs.segments)-1) {
 							curSeg = newCallFrameStackSegment()
 							cs.segIdx++
 							cs.segments[cs.segIdx] = curSeg
+							cs.segSp = 0
 						} else {
 							panic("lua callstack overflow")
 						}
 					}
-					curSeg.array[curSeg.sp] = v
-					curSeg.array[curSeg.sp].Idx = int(curSeg.sp) + FramesPerSegment*int(cs.segIdx)
-					curSeg.sp++
+					curSeg.array[cs.segSp] = v
+					curSeg.array[cs.segSp].Idx = int(cs.segSp) + FramesPerSegment*int(cs.segIdx)
+					cs.segSp++
 				}
 				newcf := ls.stack.Last()
 				// this section is inlined by go-inline

--- a/vm.go
+++ b/vm.go
@@ -137,9 +137,7 @@ func callGFunction(L *LState, tailcall bool) bool {
 	frame := L.currentFrame
 	gfnret := frame.Fn.GFunction(L)
 	if tailcall {
-		//L.stack.Remove(L.stack.Sp() - 2) // remove caller lua function frame
-		//L.currentFrame = L.stack.Last()
-		L.currentFrame = L.stack.RemoveCallerFrame()
+		L.currentFrame = L.RemoveCallerFrame()
 	}
 
 	if gfnret < 0 {

--- a/vm.go
+++ b/vm.go
@@ -116,6 +116,15 @@ func copyReturnValues(L *LState, regv, start, n, b int) { // +inline-start
 				rg := L.reg
 				regm := regv + b - 1
 				n := n - (b - 1)
+				newSize := regm + n
+				// this section is inlined by go-inline
+				// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+				{
+					requiredSize := newSize
+					if requiredSize > cap(rg.array) {
+						rg.resize(requiredSize)
+					}
+				}
 				for i := 0; i < n; i++ {
 					rg.array[regm+i] = LNil
 				}
@@ -1053,6 +1062,15 @@ func init() {
 								rg := L.reg
 								regm := regv + b - 1
 								n := n - (b - 1)
+								newSize := regm + n
+								// this section is inlined by go-inline
+								// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+								{
+									requiredSize := newSize
+									if requiredSize > cap(rg.array) {
+										rg.resize(requiredSize)
+									}
+								}
 								for i := 0; i < n; i++ {
 									rg.array[regm+i] = LNil
 								}
@@ -1122,6 +1140,15 @@ func init() {
 							rg := L.reg
 							regm := regv + b - 1
 							n := n - (b - 1)
+							newSize := regm + n
+							// this section is inlined by go-inline
+							// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+							{
+								requiredSize := newSize
+								if requiredSize > cap(rg.array) {
+									rg.resize(requiredSize)
+								}
+							}
 							for i := 0; i < n; i++ {
 								rg.array[regm+i] = LNil
 							}


### PR DESCRIPTION
Fixes #197  .

Changes proposed in this pull request:

* Memory savings:
  * Can optionally set the `LState`'s callstack to grow / shrink automatically (up to a max size)
  * Can optionally set the `LState`'s registry to grow automatically (up to a max size)

It's been a long time since I opened #197 , sorry for the delay. Please feel free to feedback on this PR or ask for changes.

There are two parts to this PR - first the registry can be set to auto grow as needed. Originally, the registry was implemented as a fixed size slice. This PR simply allows this slice to be reallocated if it runs out of space. A maximum upper size to be set in the `Options` struct, as well as a grow step size. By default the `RegistryMaxSize` will be `0`, which disables the auto grow behaviour and makes the code behaviour exactly the same as previously. As there is no penalty in this case, other than an inlined if statement, I have not abstracted the registry growth functionality via an interface.

The second part of this PR is the more complicated, it allows the callstack to be automatically resized as needed. This has been implemented now via an interface with the `LState` being configured on construction to either use the previous fixed size callstack, or the new auto growing callstack from this PR. The `Options` struct dictates which one should be used.

Abstracting the callstack into an interface is good in that it allows us to switch between implementations depending on the requirements : the auto growing one will use minimal memory, but has a slight performance penalty, whereas the fixed one will always use "worst case" memory, but will have predicable and fast performance.

Abstracting the callstack to be behind an interface has meant disabling the inlining which was in place for manipulating the stack from within the `LState`. I have added benchmarks which just do stack manipulation and I did not think the performance hit was so bad, but it might be worth benchmaking the new code (in both the fixed and auto growing configurations) against some actual lua benchmarking scripts, to see how it fares in actual usage.