### PR TITLE
Remove unused and potentially bugged function

### DIFF
--- a/_state.go
+++ b/_state.go
@@ -179,28 +179,6 @@ func (cs *fixedCallFrameStack) Push(v callFrame) {
 	cs.sp++
 }
 
-func (cs *fixedCallFrameStack) Remove(sp int) {
-	psp := sp - 1
-	nsp := sp + 1
-	var pre *callFrame
-	var next *callFrame
-	if psp > 0 {
-		pre = &cs.array[psp]
-	}
-	if nsp < cs.sp {
-		next = &cs.array[nsp]
-	}
-	if next != nil {
-		next.Parent = pre
-	}
-	for i := sp; i+1 < cs.sp; i++ {
-		cs.array[i] = cs.array[i+1]
-		cs.array[i].Idx = i
-		cs.sp = i
-	}
-	cs.sp++
-}
-
 func (cs *fixedCallFrameStack) Sp() int {
 	return cs.sp
 }

--- a/state.go
+++ b/state.go
@@ -183,28 +183,6 @@ func (cs *fixedCallFrameStack) Push(v callFrame) {
 	cs.sp++
 }
 
-func (cs *fixedCallFrameStack) Remove(sp int) {
-	psp := sp - 1
-	nsp := sp + 1
-	var pre *callFrame
-	var next *callFrame
-	if psp > 0 {
-		pre = &cs.array[psp]
-	}
-	if nsp < cs.sp {
-		next = &cs.array[nsp]
-	}
-	if next != nil {
-		next.Parent = pre
-	}
-	for i := sp; i+1 < cs.sp; i++ {
-		cs.array[i] = cs.array[i+1]
-		cs.array[i].Idx = i
-		cs.sp = i
-	}
-	cs.sp++
-}
-
 func (cs *fixedCallFrameStack) Sp() int {
 	return cs.sp
 }


### PR DESCRIPTION
LState.Remove() appears to be flawed if used to remove more
than 1 callframe, but is no longer needed in any case.

Fixes #189.

Note: my last PR added `RemoveCallerFrame()` which is now used
instead of `LState.Remove()`, hence this function becoming unused.

I should have removed it in my last PR, sorry about that.