### PR TITLE
Do not use unsafe to take address of slice element

### DIFF
--- a/alloc.go
+++ b/alloc.go
@@ -68,7 +68,7 @@ func (al *allocator) LNumber2I(v LNumber) LValue {
 
 	// alloc a new float, and store our value into it
 	al.fptrs = append(al.fptrs, float64(v))
-	fptr := (*float64)(unsafe.Pointer(al.fheader.Data + uintptr(len(al.fptrs)-1)*unsafe.Sizeof(_fv)))
+	fptr := &al.fptrs[len(al.fptrs)-1]
 
 	// hack our scratch LValue to point to our allocated value
 	// this scratch lvalue is copied when this function returns meaning the scratch value can be reused


### PR DESCRIPTION
Fixes #254.

Changes proposed in this pull request:

- Don't use `unsafe` to take the address of a slice element, as suggested in: https://github.com/yuin/gopher-lua/issues/254#issuecomment-553175734

Note that this still doesn't make this repo pass in `-race` mode (which should really be looked into).
