### PR TITLE
improve error message when indexing non-table

### DIFF
--- a/_state.go
+++ b/_state.go
@@ -1031,7 +1031,7 @@ func (ls *LState) getField(obj LValue, key LValue) LValue {
 		metaindex := ls.metaOp1(curobj, "__index")
 		if metaindex == LNil {
 			if !istable {
-				ls.RaiseError("attempt to index a non-table object(%v)", curobj.Type().String())
+				ls.RaiseError("attempt to index a non-table object(%v) with key '%s'", curobj.Type().String(), key.String())
 			}
 			return LNil
 		}
@@ -1062,7 +1062,7 @@ func (ls *LState) getFieldString(obj LValue, key string) LValue {
 		metaindex := ls.metaOp1(curobj, "__index")
 		if metaindex == LNil {
 			if !istable {
-				ls.RaiseError("attempt to index a non-table object(%v)", curobj.Type().String())
+				ls.RaiseError("attempt to index a non-table object(%v) with key '%s'", curobj.Type().String(), key)
 			}
 			return LNil
 		}
@@ -1093,7 +1093,7 @@ func (ls *LState) setField(obj LValue, key LValue, value LValue) {
 		metaindex := ls.metaOp1(curobj, "__newindex")
 		if metaindex == LNil {
 			if !istable {
-				ls.RaiseError("attempt to index a non-table object(%v)", curobj.Type().String())
+				ls.RaiseError("attempt to index a non-table object(%v) with key '%s'", curobj.Type().String(), key.String())
 			}
 			ls.RawSet(tb, key, value)
 			return
@@ -1125,7 +1125,7 @@ func (ls *LState) setFieldString(obj LValue, key string, value LValue) {
 		metaindex := ls.metaOp1(curobj, "__newindex")
 		if metaindex == LNil {
 			if !istable {
-				ls.RaiseError("attempt to index a non-table object(%v)", curobj.Type().String())
+				ls.RaiseError("attempt to index a non-table object(%v) with key '%s'", curobj.Type().String(), key)
 			}
 			tb.RawSetString(key, value)
 			return

--- a/state.go
+++ b/state.go
@@ -1186,7 +1186,7 @@ func (ls *LState) getField(obj LValue, key LValue) LValue {
 		metaindex := ls.metaOp1(curobj, "__index")
 		if metaindex == LNil {
 			if !istable {
-				ls.RaiseError("attempt to index a non-table object(%v)", curobj.Type().String())
+				ls.RaiseError("attempt to index a non-table object(%v) with key '%s'", curobj.Type().String(), key.String())
 			}
 			return LNil
 		}
@@ -1217,7 +1217,7 @@ func (ls *LState) getFieldString(obj LValue, key string) LValue {
 		metaindex := ls.metaOp1(curobj, "__index")
 		if metaindex == LNil {
 			if !istable {
-				ls.RaiseError("attempt to index a non-table object(%v)", curobj.Type().String())
+				ls.RaiseError("attempt to index a non-table object(%v) with key '%s'", curobj.Type().String(), key)
 			}
 			return LNil
 		}
@@ -1248,7 +1248,7 @@ func (ls *LState) setField(obj LValue, key LValue, value LValue) {
 		metaindex := ls.metaOp1(curobj, "__newindex")
 		if metaindex == LNil {
 			if !istable {
-				ls.RaiseError("attempt to index a non-table object(%v)", curobj.Type().String())
+				ls.RaiseError("attempt to index a non-table object(%v) with key '%s'", curobj.Type().String(), key.String())
 			}
 			ls.RawSet(tb, key, value)
 			return
@@ -1280,7 +1280,7 @@ func (ls *LState) setFieldString(obj LValue, key string, value LValue) {
 		metaindex := ls.metaOp1(curobj, "__newindex")
 		if metaindex == LNil {
 			if !istable {
-				ls.RaiseError("attempt to index a non-table object(%v)", curobj.Type().String())
+				ls.RaiseError("attempt to index a non-table object(%v) with key '%s'", curobj.Type().String(), key)
 			}
 			tb.RawSetString(key, value)
 			return


### PR DESCRIPTION
when indexing a non-table object, it was sometimes hard to
understand missing key errors:
eg.
 a.b.c = 5
 > error was "attempt to index a non-table object(nil)"
was 'a' nil or 'a.b' nil?
now the error is:
 > error was "attempt to index a non-table object(nil) with key 'b'"

Fixes #264 

Changes proposed in this pull request:

Detail given on #264 