### PR TITLE
Leaking locals fix

### DIFF
--- a/_state.go
+++ b/_state.go
@@ -449,7 +449,8 @@ func (rg *registry) Get(reg int) LValue {
 // are nilled out. (So top will be regv+n)
 // CopyRange should ideally be renamed to MoveRange.
 func (rg *registry) CopyRange(regv, start, limit, n int) { // +inline-start
-	rg.checkSize(regv + n)
+	newSize := regv + n
+	// +inline-call rg.checkSize newSize
 	if limit == -1 || limit > rg.top {
 		limit = rg.top
 	}

--- a/_state.go
+++ b/_state.go
@@ -439,17 +439,39 @@ func (rg *registry) Get(reg int) LValue {
 	return rg.array[reg]
 }
 
+// CopyRange will move a section of values from index `start` to index `regv`
+// It will move `n` values.
+// `limit` specifies the maximum end range that can be copied from. If it's set to -1, then it defaults to stopping at
+// the top of the registry (values beyond the top are not initialized, so if specifying an alternative `limit` you should
+// pass a value <= rg.top.
+// If start+n is beyond the limit, then nil values will be copied to the destination slots.
+// After the copy, the registry is truncated to be at the end of the copied range, ie the original of the copied values
+// are nilled out.
+// CopyRange should ideally be renamed to MoveRange.
 func (rg *registry) CopyRange(regv, start, limit, n int) { // +inline-start
-	newSize := regv + n
-	// +inline-call rg.checkSize newSize
+	rg.checkSize(regv + n)
+	if limit == -1 || limit > rg.top {
+		limit = rg.top
+	}
 	for i := 0; i < n; i++ {
-		if tidx := start + i; tidx >= rg.top || limit > -1 && tidx >= limit || tidx < 0 {
+		srcIdx := start + i
+		if srcIdx >= limit || srcIdx < 0 {
 			rg.array[regv+i] = LNil
 		} else {
-			rg.array[regv+i] = rg.array[tidx]
+			rg.array[regv+i] = rg.array[srcIdx]
 		}
 	}
+
+	// values beyond top don't need to be valid LValues, so setting them to nil is fine
+	// setting them to nil rather than LNil lets us invoke the golang memclr opto
+	oldtop := rg.top
 	rg.top = regv + n
+	if rg.top < oldtop {
+		nilRange := rg.array[rg.top:oldtop]
+		for i := range nilRange {
+			nilRange[i] = nil
+		}
+	}
 } // +inline-end
 
 func (rg *registry) FillNil(regm, n int) { // +inline-start

--- a/_state.go
+++ b/_state.go
@@ -446,7 +446,7 @@ func (rg *registry) Get(reg int) LValue {
 // pass a value <= rg.top.
 // If start+n is beyond the limit, then nil values will be copied to the destination slots.
 // After the copy, the registry is truncated to be at the end of the copied range, ie the original of the copied values
-// are nilled out.
+// are nilled out. (So top will be regv+n)
 // CopyRange should ideally be renamed to MoveRange.
 func (rg *registry) CopyRange(regv, start, limit, n int) { // +inline-start
 	rg.checkSize(regv + n)
@@ -474,13 +474,23 @@ func (rg *registry) CopyRange(regv, start, limit, n int) { // +inline-start
 	}
 } // +inline-end
 
+// FillNil fills the registry with nil values from regm to regm+n and then sets the registry top to regm+n
 func (rg *registry) FillNil(regm, n int) { // +inline-start
 	newSize := regm + n
 	// +inline-call rg.checkSize newSize
 	for i := 0; i < n; i++ {
 		rg.array[regm+i] = LNil
 	}
+	// values beyond top don't need to be valid LValues, so setting them to nil is fine
+	// setting them to nil rather than LNil lets us invoke the golang memclr opto
+	oldtop := rg.top
 	rg.top = regm + n
+	if rg.top < oldtop {
+		nilRange := rg.array[rg.top:oldtop]
+		for i := range nilRange {
+			nilRange[i] = nil
+		}
+	}
 } // +inline-end
 
 func (rg *registry) Insert(value LValue, reg int) {

--- a/_vm.go
+++ b/_vm.go
@@ -60,6 +60,13 @@ func mainLoopWithContext(L *LState, baseframe *callFrame) {
 	}
 }
 
+// regv is the first target register to copy the return values to.
+// It can be reg.top, indicating that the copied values are going into new registers, or it can be below reg.top
+// Indicating that the values should be within the existing registers.
+// b is the available number of return values + 1.
+// n is the desired number of return values.
+// If n more than the available return values then the extra values are set to nil.
+// When this function returns the top of the registry will be set to regv+n.
 func copyReturnValues(L *LState, regv, start, n, b int) { // +inline-start
 	if b == 1 {
 		// +inline-call L.reg.FillNil  regv n

--- a/state.go
+++ b/state.go
@@ -467,7 +467,15 @@ func (rg *registry) Get(reg int) LValue {
 // are nilled out. (So top will be regv+n)
 // CopyRange should ideally be renamed to MoveRange.
 func (rg *registry) CopyRange(regv, start, limit, n int) { // +inline-start
-	rg.checkSize(regv + n)
+	newSize := regv + n
+	// this section is inlined by go-inline
+	// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+	{
+		requiredSize := newSize
+		if requiredSize > cap(rg.array) {
+			rg.resize(requiredSize)
+		}
+	}
 	if limit == -1 || limit > rg.top {
 		limit = rg.top
 	}

--- a/state.go
+++ b/state.go
@@ -457,24 +457,39 @@ func (rg *registry) Get(reg int) LValue {
 	return rg.array[reg]
 }
 
+// CopyRange will move a section of values from index `start` to index `regv`
+// It will move `n` values.
+// `limit` specifies the maximum end range that can be copied from. If it's set to -1, then it defaults to stopping at
+// the top of the registry (values beyond the top are not initialized, so if specifying an alternative `limit` you should
+// pass a value <= rg.top.
+// If start+n is beyond the limit, then nil values will be copied to the destination slots.
+// After the copy, the registry is truncated to be at the end of the copied range, ie the original of the copied values
+// are nilled out.
+// CopyRange should ideally be renamed to MoveRange.
 func (rg *registry) CopyRange(regv, start, limit, n int) { // +inline-start
-	newSize := regv + n
-	// this section is inlined by go-inline
-	// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
-	{
-		requiredSize := newSize
-		if requiredSize > cap(rg.array) {
-			rg.resize(requiredSize)
-		}
+	rg.checkSize(regv + n)
+	if limit == -1 || limit > rg.top {
+		limit = rg.top
 	}
 	for i := 0; i < n; i++ {
-		if tidx := start + i; tidx >= rg.top || limit > -1 && tidx >= limit || tidx < 0 {
+		srcIdx := start + i
+		if srcIdx >= limit || srcIdx < 0 {
 			rg.array[regv+i] = LNil
 		} else {
-			rg.array[regv+i] = rg.array[tidx]
+			rg.array[regv+i] = rg.array[srcIdx]
 		}
 	}
+
+	// values beyond top don't need to be valid LValues, so setting them to nil is fine
+	// setting them to nil rather than LNil lets us invoke the golang memclr opto
+	oldtop := rg.top
 	rg.top = regv + n
+	if rg.top < oldtop {
+		nilRange := rg.array[rg.top:oldtop]
+		for i := range nilRange {
+			nilRange[i] = nil
+		}
+	}
 } // +inline-end
 
 func (rg *registry) FillNil(regm, n int) { // +inline-start

--- a/vm.go
+++ b/vm.go
@@ -64,6 +64,13 @@ func mainLoopWithContext(L *LState, baseframe *callFrame) {
 	}
 }
 
+// regv is the first target register to copy the return values to.
+// It can be reg.top, indicating that the copied values are going into new registers, or it can be below reg.top
+// Indicating that the values should be within the existing registers.
+// b is the available number of return values + 1.
+// n is the desired number of return values.
+// If n more than the available return values then the extra values are set to nil.
+// When this function returns the top of the registry will be set to regv+n.
 func copyReturnValues(L *LState, regv, start, n, b int) { // +inline-start
 	if b == 1 {
 		// this section is inlined by go-inline
@@ -83,7 +90,16 @@ func copyReturnValues(L *LState, regv, start, n, b int) { // +inline-start
 			for i := 0; i < n; i++ {
 				rg.array[regm+i] = LNil
 			}
+			// values beyond top don't need to be valid LValues, so setting them to nil is fine
+			// setting them to nil rather than LNil lets us invoke the golang memclr opto
+			oldtop := rg.top
 			rg.top = regm + n
+			if rg.top < oldtop {
+				nilRange := rg.array[rg.top:oldtop]
+				for i := range nilRange {
+					nilRange[i] = nil
+				}
+			}
 		}
 	} else {
 		// this section is inlined by go-inline
@@ -134,7 +150,16 @@ func copyReturnValues(L *LState, regv, start, n, b int) { // +inline-start
 				for i := 0; i < n; i++ {
 					rg.array[regm+i] = LNil
 				}
+				// values beyond top don't need to be valid LValues, so setting them to nil is fine
+				// setting them to nil rather than LNil lets us invoke the golang memclr opto
+				oldtop := rg.top
 				rg.top = regm + n
+				if rg.top < oldtop {
+					nilRange := rg.array[rg.top:oldtop]
+					for i := range nilRange {
+						nilRange[i] = nil
+					}
+				}
 			}
 		}
 	}
@@ -1047,7 +1072,16 @@ func init() {
 							for i := 0; i < n; i++ {
 								rg.array[regm+i] = LNil
 							}
+							// values beyond top don't need to be valid LValues, so setting them to nil is fine
+							// setting them to nil rather than LNil lets us invoke the golang memclr opto
+							oldtop := rg.top
 							rg.top = regm + n
+							if rg.top < oldtop {
+								nilRange := rg.array[rg.top:oldtop]
+								for i := range nilRange {
+									nilRange[i] = nil
+								}
+							}
 						}
 					} else {
 						// this section is inlined by go-inline
@@ -1098,7 +1132,16 @@ func init() {
 								for i := 0; i < n; i++ {
 									rg.array[regm+i] = LNil
 								}
+								// values beyond top don't need to be valid LValues, so setting them to nil is fine
+								// setting them to nil rather than LNil lets us invoke the golang memclr opto
+								oldtop := rg.top
 								rg.top = regm + n
+								if rg.top < oldtop {
+									nilRange := rg.array[rg.top:oldtop]
+									for i := range nilRange {
+										nilRange[i] = nil
+									}
+								}
 							}
 						}
 					}
@@ -1131,7 +1174,16 @@ func init() {
 						for i := 0; i < n; i++ {
 							rg.array[regm+i] = LNil
 						}
+						// values beyond top don't need to be valid LValues, so setting them to nil is fine
+						// setting them to nil rather than LNil lets us invoke the golang memclr opto
+						oldtop := rg.top
 						rg.top = regm + n
+						if rg.top < oldtop {
+							nilRange := rg.array[rg.top:oldtop]
+							for i := range nilRange {
+								nilRange[i] = nil
+							}
+						}
 					}
 				} else {
 					// this section is inlined by go-inline
@@ -1182,7 +1234,16 @@ func init() {
 							for i := 0; i < n; i++ {
 								rg.array[regm+i] = LNil
 							}
+							// values beyond top don't need to be valid LValues, so setting them to nil is fine
+							// setting them to nil rather than LNil lets us invoke the golang memclr opto
+							oldtop := rg.top
 							rg.top = regm + n
+							if rg.top < oldtop {
+								nilRange := rg.array[rg.top:oldtop]
+								for i := range nilRange {
+									nilRange[i] = nil
+								}
+							}
 						}
 					}
 				}

--- a/vm.go
+++ b/vm.go
@@ -107,7 +107,15 @@ func copyReturnValues(L *LState, regv, start, n, b int) { // +inline-start
 		{
 			rg := L.reg
 			limit := -1
-			rg.checkSize(regv + n)
+			newSize := regv + n
+			// this section is inlined by go-inline
+			// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+			{
+				requiredSize := newSize
+				if requiredSize > cap(rg.array) {
+					rg.resize(requiredSize)
+				}
+			}
 			if limit == -1 || limit > rg.top {
 				limit = rg.top
 			}
@@ -219,7 +227,15 @@ func callGFunction(L *LState, tailcall bool) bool {
 		start := L.reg.Top() - gfnret
 		limit := -1
 		n := wantret
-		rg.checkSize(regv + n)
+		newSize := regv + n
+		// this section is inlined by go-inline
+		// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+		{
+			requiredSize := newSize
+			if requiredSize > cap(rg.array) {
+				rg.resize(requiredSize)
+			}
+		}
 		if limit == -1 || limit > rg.top {
 			limit = rg.top
 		}
@@ -982,7 +998,15 @@ func init() {
 					start := RA
 					limit := -1
 					n := reg.Top() - RA - 1
-					rg.checkSize(regv + n)
+					newSize := regv + n
+					// this section is inlined by go-inline
+					// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+					{
+						requiredSize := newSize
+						if requiredSize > cap(rg.array) {
+							rg.resize(requiredSize)
+						}
+					}
 					if limit == -1 || limit > rg.top {
 						limit = rg.top
 					}
@@ -1089,7 +1113,15 @@ func init() {
 						{
 							rg := L.reg
 							limit := -1
-							rg.checkSize(regv + n)
+							newSize := regv + n
+							// this section is inlined by go-inline
+							// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+							{
+								requiredSize := newSize
+								if requiredSize > cap(rg.array) {
+									rg.resize(requiredSize)
+								}
+							}
 							if limit == -1 || limit > rg.top {
 								limit = rg.top
 							}
@@ -1191,7 +1223,15 @@ func init() {
 					{
 						rg := L.reg
 						limit := -1
-						rg.checkSize(regv + n)
+						newSize := regv + n
+						// this section is inlined by go-inline
+						// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+						{
+							requiredSize := newSize
+							if requiredSize > cap(rg.array) {
+								rg.resize(requiredSize)
+							}
+						}
 						if limit == -1 || limit > rg.top {
 							limit = rg.top
 						}
@@ -1420,7 +1460,15 @@ func init() {
 				start := cf.Base + nparams + 1
 				limit := cf.LocalBase
 				n := nwant
-				rg.checkSize(regv + n)
+				newSize := regv + n
+				// this section is inlined by go-inline
+				// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+				{
+					requiredSize := newSize
+					if requiredSize > cap(rg.array) {
+						rg.resize(requiredSize)
+					}
+				}
 				if limit == -1 || limit > rg.top {
 					limit = rg.top
 				}


### PR DESCRIPTION
Fixes #227  (mostly).

Changes proposed in this pull request:

`CopyRange` and `FillNil` can both truncate the registry by moving `reg.top` down to a lower value; however they neglected to nil out the values in the registry left abandoned by the top having moved. This meant that although the values were no longer referenced from Lua's point of view, they could not be GC-ed by Go; under the right circumstances, quite large memory leaks could be created that would only be collected when the registers happened to be overwritten, or if the `LState` itself was destroyed and GC-ed.

I have modified `CopyRange` and `FillNil` to nil out the abandoned registers and I have added a unit test to show the original issue and prove the fix.

Note, I say that it mostly fixes #227 as the remaining problem of 227 is simply that the current implementation of the Go scavenger is very slow at releasing memory back to the system. It does do it eventually, but it can take a very long time (see comments on 227)