### PR TITLE
Table alloc tracking

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -281,6 +281,14 @@ Other potential sources of Lua memory growth
 
 Limiting the growth and number of tables does not fix all possible memory leaks in Lua scripts. It is also possible for example that a script could create an ever growing string by concatenating repeatedly. At this time, there is no way of limiting this in GopherLua.
 
+++++++++++++++++++++++++++++++++++++++++++++
+Table alloc tracking and Go Lua functions
+++++++++++++++++++++++++++++++++++++++++++++
+
+If you are implementing Lua functions in Go which create ``LTables`` using `L.NewTable()`, then those tables will automatically be added to the quota count of the ``LState``. However, if you wish, you can create extra ``LTableAllocInfos`` should you want to track ``LTables`` created by your Go functions separately. To do this, call `NewTableAllocInfo` to create a new ``LTableAllocInfo`` and then set it on the ``LTable`` with `SetAllocInfo`.
+
+If you have Go Lua functions which set keys in ``LTables``, then all methods of setting keys will correctly adjust the key count. Additionally, if setting the keys via `SetField`, then a Lua error will be raised in that ``LState`` if the max key count is exceeded.
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Miscellaneous lua.NewState options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/_state.go
+++ b/_state.go
@@ -104,6 +104,14 @@ type Options struct {
 	// If `MinimizeStackMemory` is set, the call stack will be automatically grown or shrank up to a limit of
 	// `CallStackSize` in order to minimize memory usage. This does incur a slight performance penalty.
 	MinimizeStackMemory bool
+	// MaxTables and MaxTotalTableKey are used to apply memory quotas to LStates.
+	// Set them to a number to have an LState raise an error if too many tables, or too many keys (across all tables)
+	// are created. If set to 0 no tracking will be done. Tracking incurs a slight performance overhead to script
+	// execution time and may increase the number of GC cycles needed to fully collect garbage.
+	// You can set them to MaxInt32 if you want tracking enabled but don't want to particularly enforce a quota.
+	// They both default to 0, meaning to tracking / quota is enforced by default.
+	MaxTables         int32
+	MaxTotalTableKeys int32
 }
 
 /* }}} */
@@ -582,6 +590,9 @@ func newLState(options Options) *LState {
 	} else {
 		ls.stack = newFixedCallFrameStack(options.CallStackSize)
 	}
+	if options.MaxTables != 0 || options.MaxTotalTableKeys != 0 {
+		ls.tblAllocInfo = &LTableAllocInfo{maxKeys: options.MaxTotalTableKeys, maxTables: options.MaxTables}
+	}
 	ls.reg = newRegistry(ls, options.RegistrySize, options.RegistryGrowStep, options.RegistryMaxSize, al)
 	ls.Env = ls.G.Global
 	return ls
@@ -986,7 +997,7 @@ func (ls *LState) initCallFrame(cf *callFrame) { // +inline-start
 			if CompatVarArg {
 				ls.reg.SetTop(cf.LocalBase + nargs + np + 1)
 				if (proto.IsVarArg & VarArgNeedsArg) != 0 {
-					argtb := newLTable(nvarargs, 0)
+					argtb := ls.CreateTable(nvarargs, 0)
 					for i := 0; i < nvarargs; i++ {
 						argtb.RawSetInt(i+1, ls.reg.Get(cf.LocalBase+np+i))
 					}
@@ -1120,6 +1131,7 @@ func (ls *LState) setField(obj LValue, key LValue, value LValue) {
 		if istable {
 			if tb.RawGet(key) != LNil {
 				ls.RawSet(tb, key, value)
+				// no need to check table quotas after this RawSet, as the key already existed
 				return
 			}
 		}
@@ -1129,6 +1141,8 @@ func (ls *LState) setField(obj LValue, key LValue, value LValue) {
 				ls.RaiseError("attempt to index a non-table object(%v) with key '%s'", curobj.Type().String(), key.String())
 			}
 			ls.RawSet(tb, key, value)
+			// potentially a new key was created, so check the quota
+			tb.CheckQuota(ls)
 			return
 		}
 		if metaindex.Type() == LTFunction {
@@ -1152,6 +1166,7 @@ func (ls *LState) setFieldString(obj LValue, key string, value LValue) {
 		if istable {
 			if tb.RawGetString(key) != LNil {
 				tb.RawSetString(key, value)
+				// no need to check table quotas after this RawSet, as the key already existed
 				return
 			}
 		}
@@ -1161,6 +1176,8 @@ func (ls *LState) setFieldString(obj LValue, key string, value LValue) {
 				ls.RaiseError("attempt to index a non-table object(%v) with key '%s'", curobj.Type().String(), key)
 			}
 			tb.RawSetString(key, value)
+			// potentially a new key was created, so check the quota
+			tb.CheckQuota(ls)
 			return
 		}
 		if metaindex.Type() == LTFunction {
@@ -1376,11 +1393,15 @@ func (ls *LState) Remove(index int) {
 /* object allocation {{{ */
 
 func (ls *LState) NewTable() *LTable {
-	return newLTable(defaultArrayCap, defaultHashCap)
+	return ls.CreateTable(defaultArrayCap, defaultHashCap)
 }
 
 func (ls *LState) CreateTable(acap, hcap int) *LTable {
-	return newLTable(acap, hcap)
+	tbl := newLTable(acap, hcap)
+	if ls.tblAllocInfo != nil {
+		tbl.SetAllocInfo(ls, ls.tblAllocInfo)
+	}
+	return tbl
 }
 
 // NewThread returns a new LState that shares with the original state all global objects.
@@ -1720,6 +1741,12 @@ func (ls *LState) SetGlobal(name string, value LValue) {
 
 func (ls *LState) Next(tb *LTable, key LValue) (LValue, LValue) {
 	return tb.Next(key)
+}
+
+// GetTableAllocInfo returns the info on table usage for this LState. It can return nil if the LState
+// has not been configured to track the table data (see `Options` config struct)
+func (ls *LState) GetTableAllocInfo() *LTableAllocInfo {
+	return ls.tblAllocInfo
 }
 
 /* }}} */

--- a/_vm.go
+++ b/_vm.go
@@ -330,7 +330,8 @@ func init() {
 			RA := lbase + A
 			B := int(inst & 0x1ff)    //GETB
 			C := int(inst>>9) & 0x1ff //GETC
-			reg.Set(RA, newLTable(B, C))
+			tbl := L.CreateTable(B, C)
+			reg.Set(RA, tbl)
 			return 0
 		},
 		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_SELF

--- a/state.go
+++ b/state.go
@@ -636,9 +636,6 @@ func newLState(options Options) *LState {
 	} else {
 		ls.stack = newFixedCallFrameStack(options.CallStackSize)
 	}
-	if options.MaxTables != 0 || options.MaxTotalTableKeys != 0 {
-		ls.tblAllocInfo = &LTableAllocInfo{maxKeys: options.MaxTotalTableKeys, maxTables: options.MaxTables}
-	}
 	ls.reg = newRegistry(ls, options.RegistrySize, options.RegistryGrowStep, options.RegistryMaxSize, al)
 	ls.Env = ls.G.Global
 	return ls
@@ -1380,6 +1377,19 @@ func NewState(opts ...Options) *LState {
 		if !opts[0].SkipOpenLibs {
 			ls.OpenLibs()
 		}
+		// initialise the table memory tracking *after* opening the base libs, so that any tables created by the
+		// base lib opening are not counted against the quota for this LState.
+		// If for some reason you want the base libs to be counted, pass SkipOpenLibs and then explicitly load the libs
+		// with a separate call to OpenLibs from the calling code.
+		if opts[0].MaxTables != 0 || opts[0].MaxTotalTableKeys != 0 {
+			if opts[0].MaxTables == 0 {
+				opts[0].MaxTables = math.MaxInt32
+			}
+			if opts[0].MaxTotalTableKeys == 0 {
+				opts[0].MaxTotalTableKeys = math.MaxInt32
+			}
+			ls.tblAllocInfo = &LTableAllocInfo{maxKeys: opts[0].MaxTotalTableKeys, maxTables: opts[0].MaxTables}
+		}
 	}
 	return ls
 }
@@ -1565,6 +1575,7 @@ func (ls *LState) NewThread() (*LState, context.CancelFunc) {
 	thread := newLState(ls.Options)
 	thread.G = ls.G
 	thread.Env = ls.Env
+	thread.tblAllocInfo = ls.tblAllocInfo
 	var f context.CancelFunc = nil
 	if ls.ctx != nil {
 		thread.mainLoop = mainLoopWithContext

--- a/state.go
+++ b/state.go
@@ -108,6 +108,14 @@ type Options struct {
 	// If `MinimizeStackMemory` is set, the call stack will be automatically grown or shrank up to a limit of
 	// `CallStackSize` in order to minimize memory usage. This does incur a slight performance penalty.
 	MinimizeStackMemory bool
+	// MaxTables and MaxTotalTableKey are used to apply memory quotas to LStates.
+	// Set them to a number to have an LState raise an error if too many tables, or too many keys (across all tables)
+	// are created. If set to 0 no tracking will be done. Tracking incurs a slight performance overhead to script
+	// execution time and may increase the number of GC cycles needed to fully collect garbage.
+	// You can set them to MaxInt32 if you want tracking enabled but don't want to particularly enforce a quota.
+	// They both default to 0, meaning to tracking / quota is enforced by default.
+	MaxTables         int32
+	MaxTotalTableKeys int32
 }
 
 /* }}} */
@@ -628,6 +636,9 @@ func newLState(options Options) *LState {
 	} else {
 		ls.stack = newFixedCallFrameStack(options.CallStackSize)
 	}
+	if options.MaxTables != 0 || options.MaxTotalTableKeys != 0 {
+		ls.tblAllocInfo = &LTableAllocInfo{maxKeys: options.MaxTotalTableKeys, maxTables: options.MaxTables}
+	}
 	ls.reg = newRegistry(ls, options.RegistrySize, options.RegistryGrowStep, options.RegistryMaxSize, al)
 	ls.Env = ls.G.Global
 	return ls
@@ -1048,7 +1059,7 @@ func (ls *LState) initCallFrame(cf *callFrame) { // +inline-start
 			if CompatVarArg {
 				ls.reg.SetTop(cf.LocalBase + nargs + np + 1)
 				if (proto.IsVarArg & VarArgNeedsArg) != 0 {
-					argtb := newLTable(nvarargs, 0)
+					argtb := ls.CreateTable(nvarargs, 0)
 					for i := 0; i < nvarargs; i++ {
 						argtb.RawSetInt(i+1, ls.reg.Get(cf.LocalBase+np+i))
 					}
@@ -1156,7 +1167,7 @@ func (ls *LState) pushCallFrame(cf callFrame, fn LValue, meta bool) { // +inline
 				if CompatVarArg {
 					ls.reg.SetTop(cf.LocalBase + nargs + np + 1)
 					if (proto.IsVarArg & VarArgNeedsArg) != 0 {
-						argtb := newLTable(nvarargs, 0)
+						argtb := ls.CreateTable(nvarargs, 0)
 						for i := 0; i < nvarargs; i++ {
 							argtb.RawSetInt(i+1, ls.reg.Get(cf.LocalBase+np+i))
 						}
@@ -1275,6 +1286,7 @@ func (ls *LState) setField(obj LValue, key LValue, value LValue) {
 		if istable {
 			if tb.RawGet(key) != LNil {
 				ls.RawSet(tb, key, value)
+				// no need to check table quotas after this RawSet, as the key already existed
 				return
 			}
 		}
@@ -1284,6 +1296,8 @@ func (ls *LState) setField(obj LValue, key LValue, value LValue) {
 				ls.RaiseError("attempt to index a non-table object(%v) with key '%s'", curobj.Type().String(), key.String())
 			}
 			ls.RawSet(tb, key, value)
+			// potentially a new key was created, so check the quota
+			tb.CheckQuota(ls)
 			return
 		}
 		if metaindex.Type() == LTFunction {
@@ -1307,6 +1321,7 @@ func (ls *LState) setFieldString(obj LValue, key string, value LValue) {
 		if istable {
 			if tb.RawGetString(key) != LNil {
 				tb.RawSetString(key, value)
+				// no need to check table quotas after this RawSet, as the key already existed
 				return
 			}
 		}
@@ -1316,6 +1331,8 @@ func (ls *LState) setFieldString(obj LValue, key string, value LValue) {
 				ls.RaiseError("attempt to index a non-table object(%v) with key '%s'", curobj.Type().String(), key)
 			}
 			tb.RawSetString(key, value)
+			// potentially a new key was created, so check the quota
+			tb.CheckQuota(ls)
 			return
 		}
 		if metaindex.Type() == LTFunction {
@@ -1531,11 +1548,15 @@ func (ls *LState) Remove(index int) {
 /* object allocation {{{ */
 
 func (ls *LState) NewTable() *LTable {
-	return newLTable(defaultArrayCap, defaultHashCap)
+	return ls.CreateTable(defaultArrayCap, defaultHashCap)
 }
 
 func (ls *LState) CreateTable(acap, hcap int) *LTable {
-	return newLTable(acap, hcap)
+	tbl := newLTable(acap, hcap)
+	if ls.tblAllocInfo != nil {
+		tbl.SetAllocInfo(ls, ls.tblAllocInfo)
+	}
+	return tbl
 }
 
 // NewThread returns a new LState that shares with the original state all global objects.
@@ -1875,6 +1896,12 @@ func (ls *LState) SetGlobal(name string, value LValue) {
 
 func (ls *LState) Next(tb *LTable, key LValue) (LValue, LValue) {
 	return tb.Next(key)
+}
+
+// GetTableAllocInfo returns the info on table usage for this LState. It can return nil if the LState
+// has not been configured to track the table data (see `Options` config struct)
+func (ls *LState) GetTableAllocInfo() *LTableAllocInfo {
+	return ls.tblAllocInfo
 }
 
 /* }}} */

--- a/tablelib.go
+++ b/tablelib.go
@@ -91,9 +91,11 @@ func tableInsert(L *LState) int {
 
 	if L.GetTop() == 2 {
 		tbl.Append(L.Get(2))
+		tbl.CheckQuota(L)
 		return 0
 	}
 	tbl.Insert(int(L.CheckInt(2)), L.CheckAny(3))
+	tbl.CheckQuota(L)
 	return 0
 }
 

--- a/vm.go
+++ b/vm.go
@@ -464,7 +464,8 @@ func init() {
 			RA := lbase + A
 			B := int(inst & 0x1ff)    //GETB
 			C := int(inst>>9) & 0x1ff //GETC
-			reg.Set(RA, newLTable(B, C))
+			tbl := L.CreateTable(B, C)
+			reg.Set(RA, tbl)
 			return 0
 		},
 		func(L *LState, inst uint32, baseframe *callFrame) int { //OP_SELF
@@ -795,7 +796,7 @@ func init() {
 							if CompatVarArg {
 								ls.reg.SetTop(cf.LocalBase + nargs + np + 1)
 								if (proto.IsVarArg & VarArgNeedsArg) != 0 {
-									argtb := newLTable(nvarargs, 0)
+									argtb := ls.CreateTable(nvarargs, 0)
 									for i := 0; i < nvarargs; i++ {
 										argtb.RawSetInt(i+1, ls.reg.Get(cf.LocalBase+np+i))
 									}
@@ -973,7 +974,7 @@ func init() {
 							if CompatVarArg {
 								ls.reg.SetTop(cf.LocalBase + nargs + np + 1)
 								if (proto.IsVarArg & VarArgNeedsArg) != 0 {
-									argtb := newLTable(nvarargs, 0)
+									argtb := ls.CreateTable(nvarargs, 0)
 									for i := 0; i < nvarargs; i++ {
 										argtb.RawSetInt(i+1, ls.reg.Get(cf.LocalBase+np+i))
 									}


### PR DESCRIPTION
Fixes #250 

Changes proposed in this pull request:

- LStates can now optionally limit how many LTables and how many LTable keys are set
- This provides basic memory quotas for LStates as LTable growth is the most common way for an LState to grow in memory use
- Defaults to not being tracked
- When enabled - has almost negligible speed and memory impact
