### PR TITLE
LState.CheckString should cast number to string and return

### DIFF
--- a/auxlib.go
+++ b/auxlib.go
@@ -48,6 +48,8 @@ func (ls *LState) CheckString(n int) string {
 	v := ls.Get(n)
 	if lv, ok := v.(LString); ok {
 		return string(lv)
+	} else if LVCanConvToString(v) {
+		return ls.ToString(n)
 	}
 	ls.TypeError(n, LTString)
 	return ""

--- a/auxlib_test.go
+++ b/auxlib_test.go
@@ -49,9 +49,11 @@ func TestCheckString(t *testing.T) {
 		L.Push(LString("aaa"))
 		errorIfNotEqual(t, "aaa", L.CheckString(2))
 		L.Push(LNumber(10))
-		L.CheckString(3)
+		errorIfNotEqual(t, "10", L.CheckString(3))
+		L.Push(L.NewTable())
+		L.CheckString(4)
 		return 0
-	}, "string expected, got number")
+	}, "string expected, got table")
 }
 
 func TestCheckBool(t *testing.T) {


### PR DESCRIPTION
LState.CheckString will fail when passed a number param, this is different with lua 5.1.This is the document from lua.org:

luaL_checklstring
const char *luaL_checklstring (lua_State *L, int narg, size_t *l);
Checks whether the function argument narg is a string and returns this string; if l is not NULL fills *l with the string's length.

**This function uses lua_tolstring to get its result, so all conversions and caveats of that function apply here.**
