### PR TITLE
Refactor LTable to improve performance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module github.com/yuin/gopher-lua
 
+go 1.14
+
 require (
 	github.com/chzyer/logex v1.1.10 // indirect
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect
-	golang.org/x/sys v0.0.0-20190204203706-41f3e6584952 // indirect
+	golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,4 @@
-github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
-github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
-github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-golang.org/x/sys v0.0.0-20190204203706-41f3e6584952 h1:FDfvYgoVsA7TTZSbgiqjAbfPbK47CNHdWl3h/PJtii0=
-golang.org/x/sys v0.0.0-20190204203706-41f3e6584952/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/table_convert_test.go
+++ b/table_convert_test.go
@@ -1,0 +1,39 @@
+package lua
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+var testingConversionJSONValue interface{}
+var testingConversionLuaValue LValue
+
+func init() {
+	resp, err := http.Get("https://raw.githubusercontent.com/valyala/fastjson/master/testdata/large.json")
+	if err != nil {
+		panic(err)
+	}
+	jsonBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
+	}
+	err = json.Unmarshal(jsonBody, &testingConversionJSONValue)
+	if err != nil {
+		panic(err)
+	}
+	testingConversionLuaValue = ConvertToLValue(testingConversionJSONValue)
+}
+
+func BenchmarkToLValue(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		ConvertToLValue(testingConversionJSONValue)
+	}
+}
+
+func BenchmarkToGValue(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		ConvertFromLValue(testingConversionLuaValue)
+	}
+}

--- a/table_test.go
+++ b/table_test.go
@@ -19,12 +19,18 @@ func TestTableLen(t *testing.T) {
 	tbl.RawSetInt(8, LNil)
 	tbl.RawSetInt(7, LNumber(10))
 	errorIfNotEqual(t, 9, tbl.Len())
+	errorIfNotEqual(t, 0, tbl.DictionaryLen())
 
 	tbl = newLTable(0, 0)
 	tbl.Append(LTrue)
 	tbl.Append(LTrue)
 	tbl.Append(LTrue)
 	errorIfNotEqual(t, 3, tbl.Len())
+
+	tbl = newLTable(0, 0)
+	tbl.RawSetString("a", LNumber(1))
+	tbl.RawSetString("b", LNumber(2))
+	errorIfNotEqual(t, 2, tbl.DictionaryLen())
 }
 
 func TestTableAppend(t *testing.T) {
@@ -206,4 +212,35 @@ func TestTableForEach(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestNext(t *testing.T) {
+	tbl := newLTable(0, 0)
+	tbl.RawSetString("a", LNumber(1))
+	tbl.RawSetString("b", LString("B"))
+	index, value := tbl.Next(LNil)
+	errorIfNotEqual(t, LString("a"), index)
+	errorIfNotEqual(t, LNumber(1), value)
+
+	index, value = tbl.Next(LString("a"))
+	errorIfNotEqual(t, LString("b"), index)
+	errorIfNotEqual(t, LString("B"), value)
+
+	tbl = newLTable(0, 0)
+	tbl.Append(LNumber(11))
+	tbl.Append(LNumber(21))
+	tbl.Append(LNumber(13))
+	tbl.Insert(2, LNil)
+	index, value = tbl.Next(LNil)
+	errorIfNotEqual(t, LNumber(1), index)
+	errorIfNotEqual(t, LNumber(11), value)
+	index, value = tbl.Next(LNumber(1))
+	errorIfNotEqual(t, LNumber(3), index)
+	errorIfNotEqual(t, LNumber(21), value)
+
+	tbl = newLTable(0, 0)
+	tbl.RawSetH(LTrue, LNumber(-10))
+	index, value = tbl.Next(LNil)
+	errorIfNotEqual(t, index, LTrue)
+	errorIfNotEqual(t, LNumber(-10), value)
 }

--- a/utils_convert.go
+++ b/utils_convert.go
@@ -1,0 +1,135 @@
+package lua
+
+import "time"
+
+// ConvertMapStringToLTable would conver a map to lua table
+func ConvertMapStringToLTable(data map[string]string) *LTable {
+	lt := newLTable(0, len(data))
+	for k, v := range data {
+		lt.RawSetString(k, LString(v))
+	}
+	return lt
+}
+
+// ConvertMapToLTable would conver a map to lua table
+func ConvertMapToLTable(data map[string]interface{}) *LTable {
+	lt := newLTable(0, len(data))
+	for k, v := range data {
+		lt.RawSetString(k, ConvertToLValue(v))
+	}
+	return lt
+}
+
+// ConvertToLValue would conver an interface value to lua value
+//   - bool: boolean
+//   - string, []byte: string
+//   - float32/64, int/32/64, uint/32/64: number
+//   - map[string][]string: table{key: table{...}, ...}
+//   - map[string]string, map[string]interface{}: table
+//   - []string, []interface{}: table
+//   - time.Time: number (UTC Unix timestamp)
+//   - nil: nil
+func ConvertToLValue(val interface{}) LValue {
+	if val == nil {
+		return LNil
+	}
+	switch v := val.(type) {
+	case bool:
+		return LBool(v)
+	case string:
+		return LString(v)
+	case []byte:
+		return LString(v)
+	case float32:
+		return LNumber(v)
+	case float64:
+		return LNumber(v)
+	case int:
+		return LNumber(v)
+	case int32:
+		return LNumber(v)
+	case int64:
+		return LNumber(v)
+	case uint:
+		return LNumber(v)
+	case uint32:
+		return LNumber(v)
+	case uint64:
+		return LNumber(v)
+	case map[string][]string:
+		lt := newLTable(0, len(v))
+		for k, v := range v {
+			lt.RawSetString(k, ConvertToLValue(v))
+		}
+		return lt
+	case map[string]string:
+		return ConvertMapStringToLTable(v)
+	case map[string]interface{}:
+		return ConvertMapToLTable(v)
+	case map[interface{}]interface{}:
+		lt := newLTable(0, len(v))
+		for k, v := range v {
+			lt.RawSet(ConvertToLValue(k), ConvertToLValue(v))
+		}
+		return lt
+	case []string:
+		lt := newLTable(len(v), 0)
+		for i := range v {
+			lt.RawSetInt(i+1, LString(v[i]))
+		}
+		return lt
+	case []interface{}:
+		lt := newLTable(len(v), 0)
+		for i := range v {
+			lt.RawSetInt(i+1, ConvertToLValue(v[i]))
+		}
+		return lt
+	case time.Time:
+		return LNumber(v.UTC().Unix())
+	default:
+		return LNil
+	}
+}
+
+// ConvertFromLValue would conver lua value to an interface value
+//  - boolean: bool
+//  - string: string
+//  - number: float64 or int64
+//  - table: map[string]interface{} or []interface{} (by MaxN)
+//  - nil: nil
+func ConvertFromLValue(lv LValue) interface{} {
+	switch v := lv.(type) {
+	case *LNilType:
+		return nil
+	case LBool:
+		return bool(v)
+	case LString:
+		return string(v)
+	case LNumber:
+		vf := float64(v)
+		vi := int64(v)
+		if vf == float64(vi) {
+			return vi
+		}
+		return vf
+	case *LTable:
+		maxn := v.MaxN()
+		if maxn == 0 {
+			// as table
+			ret := make(map[string]interface{}, v.DictionaryLen())
+			v.ForEach(func(key, value LValue) {
+				keyStr := key.String()
+				ret[keyStr] = ConvertFromLValue(value)
+			})
+			return ret
+		}
+		// as array
+		ret := make([]interface{}, maxn)
+		for i := 1; i <= maxn; i++ {
+			ret[i-1] = ConvertFromLValue(v.RawGetInt(i))
+		}
+		return ret
+	default:
+		return v
+	}
+}

--- a/value.go
+++ b/value.go
@@ -158,14 +158,17 @@ func (nm LNumber) Format(f fmt.State, c rune) {
 	}
 }
 
+type lTableDictValue struct {
+	value LValue
+	keyIndex int
+}
+
 type LTable struct {
 	Metatable LValue
 
 	array   []LValue
-	dict    map[LValue]LValue
-	strdict map[string]LValue
-	keys    []LValue
-	k2i     map[LValue]int
+	dict    map[LValue]lTableDictValue
+	keys    []*LValue
 }
 
 func (tb *LTable) String() string                     { return fmt.Sprintf("table: %p", tb) }


### PR DESCRIPTION
Improve conversion speed between lua value and go value by reduce memory allocation。

### Changes proposed in this pull request:

append lTableDictValue{value LValue, keyIndex int}.
change LTable would contains unique dict map[LValue]lTableDictValue.
change LTable#keys as []*LValue to reduce memory allocation on RawSetString.
append LTable#DictionaryLen() (use to initial go map cap).
append some convert functions between LValue and go value.

### Benchmark testing:
- Load the [28kb json](https://raw.githubusercontent.com/valyala/fastjson/master/testdata/large.json) decode as map[string]interface{}, convert to LTable and then convert back.
- original
BenchmarkToLValue-4   	    2157	    559233 ns/op	  272908 B/op	    3799 allocs/op
BenchmarkToGValue-4   	    3924	    270173 ns/op	  126799 B/op	    2025 allocs/op
- changed
BenchmarkToLValue-4   	    2704	    377055 ns/op	  187883 B/op	    3459 allocs/op
BenchmarkToGValue-4   	    6284	    169170 ns/op	   82971 B/op	     981 allocs/op

I would charge test code, if the changing would be accepted.