### PR TITLE
Add optional allowlist to os lib import

### DIFF
--- a/oslib.go
+++ b/oslib.go
@@ -35,6 +35,14 @@ func OpenOs(L *LState) int {
 	return 1
 }
 
+func OpenOsAllowlist(allowed ...string) LGFunction {
+	return func(L *LState) int {
+		osmod := L.RegisterModule(OsLibName, useAllowlist(osFuncs, allowed...))
+		L.Push(osmod)
+		return 1
+	}
+}
+
 var osFuncs = map[string]LGFunction{
 	"clock":     osClock,
 	"difftime":  osDiffTime,

--- a/oslib_test.go
+++ b/oslib_test.go
@@ -1,0 +1,39 @@
+package lua
+
+import "testing"
+
+func TestOpenOsAllowList(t *testing.T) {
+	L := NewState(Options{SkipOpenLibs: true})
+
+	for _, pair := range []struct {
+		n string
+		f LGFunction
+	}{
+		{LoadLibName, OpenPackage}, // Must be first
+		{OsLibName, OpenOsAllowlist("time")},
+	} {
+		if err := L.CallByParam(P{
+			Fn:      L.NewFunction(pair.f),
+			NRet:    0,
+			Protect: true,
+		}, LString(pair.n)); err != nil {
+			t.Fatalf("unable to load libs: %v", err)
+		}
+	}
+
+	s := `
+		os.time()
+	`
+	// Shoult NOT error out
+	if err := L.DoString(s); err != nil {
+		t.Error(err)
+	}
+
+	s = `
+		os.execute('echo "hello"')
+	`
+	// Should error out
+	if err := L.DoString(s); err == nil {
+		t.Errorf("able to run blocked function")
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -263,3 +263,11 @@ func unsafeFastStringToReadOnlyBytes(s string) (bs []byte) {
 	bh.Len = sh.Len
 	return
 }
+
+func useAllowlist(orgFuncs map[string]LGFunction, allowed ...string) map[string]LGFunction {
+	funcs := map[string]LGFunction{}
+	for _, str := range allowed {
+		funcs[str] = osFuncs[str]
+	}
+	return funcs
+}


### PR DESCRIPTION
I needed a simple way to only allow a subset of the os lib since there are some fairly dangerous functions in there.

**Changes proposed in this pull request:**
Add `OpenOsAllowlist` which applies an allow list to the oslib imports.