### PR TITLE
allowing check if LState is closed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/yuin/gopher-lua
 
+go 1.14
+
 require (
 	github.com/chzyer/logex v1.1.10 // indirect
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e

--- a/state.go
+++ b/state.go
@@ -1367,6 +1367,10 @@ func NewState(opts ...Options) *LState {
 	return ls
 }
 
+func (ls *LState) IsClosed() bool {
+	return ls.stack == nil
+}
+
 func (ls *LState) Close() {
 	atomic.AddInt32(&ls.stop, 1)
 	for _, file := range ls.G.tempFiles {

--- a/state_test.go
+++ b/state_test.go
@@ -7,6 +7,12 @@ import (
 	"time"
 )
 
+func TestLStateIsClosed(t *testing.T) {
+	L := NewState()
+	L.Close()
+	errorIfNotEqual(t, true, L.IsClosed())
+}
+
 func TestCallStackOverflowWhenFixed(t *testing.T) {
 	L := NewState(Options{
 		CallStackSize: 3,


### PR DESCRIPTION
Since `stack` is only set to `nil` upon calling `LState.Close()`. Thus we can check `stack` to tell if `LState` has been closed.

Changes proposed in this pull request:

- add `IsClosed() bool` to `LState`
