### PR TITLE
Issue #292 : os.time keep consistent with standard implementation

### DIFF
--- a/_glua-tests/issues.lua
+++ b/_glua-tests/issues.lua
@@ -264,3 +264,70 @@ function test()
   m:f2()
 end
 test()
+
+-- issue #292
+function test()
+  t0 = {}
+	t0.year = 2006
+	t0.month = 1
+	t0.day = 2
+	t0.hour = 15
+	t0.min = 4
+	t0.sec = 5
+
+	t1 = {}
+	t1.year = "2006"
+	t1.month = "1"
+	t1.day = "2"
+	t1.hour = "15"
+	t1.min = "4"
+	t1.sec = "5"
+
+	assert(os.time(t0) == os.time(t1))
+
+	t2 = {}
+	t2.year = "  2006"--prefix blank space
+	t2.month = "1"
+	t2.day = "2"
+	t2.hour = "15"
+	t2.min = "4"
+	t2.sec = "5"
+	assert(os.time(t0) == os.time(t2))
+
+	t3 = {}
+	t3.year = "  0002006"--prefix blank space and 0
+	t3.month = "1"
+	t3.day = "2"
+	t3.hour = "15"
+	t3.min = "4"
+	t3.sec = "5"
+	assert(os.time(t1) == os.time(t3))
+
+	t4 = {}
+	t4.year = "0002006"--prefix 0
+	t4.month = "1"
+	t4.day = "2"
+	t4.hour = "15"
+	t4.min = "4"
+	t4.sec = "5"
+	assert(os.time(t1) == os.time(t4))
+
+	t5 = {}
+	t5.year = "0x7d6"--prefix 0x
+	t5.month = "1"
+	t5.day = "2"
+	t5.hour = "15"
+	t5.min = "4"
+	t5.sec = "5"
+	assert(os.time(t1) == os.time(t5))
+
+	t6 = {}
+	t6.year = "0X7d6"--prefix 0X
+	t6.month = "1"
+	t6.day = "2"
+	t6.hour = "15"
+	t6.min = "4"
+	t6.sec = "5"
+	assert(os.time(t1) == os.time(t6))
+end
+test()

--- a/oslib.go
+++ b/oslib.go
@@ -15,9 +15,24 @@ func init() {
 
 func getIntField(L *LState, tb *LTable, key string, v int) int {
 	ret := tb.RawGetString(key)
-	if ln, ok := ret.(LNumber); ok {
-		return int(ln)
+
+	switch lv := ret.(type) {
+	case LNumber:
+		return int(lv)
+	case LString:
+		slv := string(lv)
+		slv = strings.TrimLeft(slv, " ")
+		if strings.HasPrefix(slv, "0") && !strings.HasPrefix(slv, "0x") && !strings.HasPrefix(slv, "0X") {
+			//Standard lua interpreter only support decimal and hexadecimal
+			slv = strings.TrimLeft(slv, "0")
+		}
+		if num, err := parseNumber(slv); err == nil {
+			return int(num)
+		}
+	default:
+		return v
 	}
+
 	return v
 }
 


### PR DESCRIPTION
Fixes #292 .

Changes proposed in this pull request:

- keep gopher-lua `os.time ([table])` consistent with standard implementation
