### PR TITLE
Nil reg entry panic fix

### DIFF
--- a/_state.go
+++ b/_state.go
@@ -936,18 +936,22 @@ func (ls *LState) initCallFrame(cf *callFrame) { // +inline-start
 		proto := cf.Fn.Proto
 		nargs := cf.NArgs
 		np := int(proto.NumParameters)
-		newSize := cf.LocalBase + np
-		// +inline-call ls.reg.checkSize newSize
-		for i := nargs; i < np; i++ {
-			ls.reg.array[cf.LocalBase+i] = LNil
+		if nargs < np {
+			// default any missing arguments to nil
+			newSize := cf.LocalBase + np
+			// +inline-call ls.reg.checkSize newSize
+			for i := nargs; i < np; i++ {
+				ls.reg.array[cf.LocalBase+i] = LNil
+			}
 			nargs = np
+			ls.reg.top = newSize
 		}
 
 		if (proto.IsVarArg & VarArgIsVarArg) == 0 {
 			if nargs < int(proto.NumUsedRegisters) {
 				nargs = int(proto.NumUsedRegisters)
 			}
-			newSize = cf.LocalBase + nargs
+			newSize := cf.LocalBase + nargs
 			// +inline-call ls.reg.checkSize newSize
 			for i := np; i < nargs; i++ {
 				ls.reg.array[cf.LocalBase+i] = LNil

--- a/state.go
+++ b/state.go
@@ -982,26 +982,30 @@ func (ls *LState) initCallFrame(cf *callFrame) { // +inline-start
 		proto := cf.Fn.Proto
 		nargs := cf.NArgs
 		np := int(proto.NumParameters)
-		newSize := cf.LocalBase + np
-		// this section is inlined by go-inline
-		// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
-		{
-			rg := ls.reg
-			requiredSize := newSize
-			if requiredSize > cap(rg.array) {
-				rg.resize(requiredSize)
+		if nargs < np {
+			// default any missing arguments to nil
+			newSize := cf.LocalBase + np
+			// this section is inlined by go-inline
+			// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+			{
+				rg := ls.reg
+				requiredSize := newSize
+				if requiredSize > cap(rg.array) {
+					rg.resize(requiredSize)
+				}
 			}
-		}
-		for i := nargs; i < np; i++ {
-			ls.reg.array[cf.LocalBase+i] = LNil
+			for i := nargs; i < np; i++ {
+				ls.reg.array[cf.LocalBase+i] = LNil
+			}
 			nargs = np
+			ls.reg.top = newSize
 		}
 
 		if (proto.IsVarArg & VarArgIsVarArg) == 0 {
 			if nargs < int(proto.NumUsedRegisters) {
 				nargs = int(proto.NumUsedRegisters)
 			}
-			newSize = cf.LocalBase + nargs
+			newSize := cf.LocalBase + nargs
 			// this section is inlined by go-inline
 			// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
 			{
@@ -1090,26 +1094,30 @@ func (ls *LState) pushCallFrame(cf callFrame, fn LValue, meta bool) { // +inline
 			proto := cf.Fn.Proto
 			nargs := cf.NArgs
 			np := int(proto.NumParameters)
-			newSize := cf.LocalBase + np
-			// this section is inlined by go-inline
-			// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
-			{
-				rg := ls.reg
-				requiredSize := newSize
-				if requiredSize > cap(rg.array) {
-					rg.resize(requiredSize)
+			if nargs < np {
+				// default any missing arguments to nil
+				newSize := cf.LocalBase + np
+				// this section is inlined by go-inline
+				// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+				{
+					rg := ls.reg
+					requiredSize := newSize
+					if requiredSize > cap(rg.array) {
+						rg.resize(requiredSize)
+					}
 				}
-			}
-			for i := nargs; i < np; i++ {
-				ls.reg.array[cf.LocalBase+i] = LNil
+				for i := nargs; i < np; i++ {
+					ls.reg.array[cf.LocalBase+i] = LNil
+				}
 				nargs = np
+				ls.reg.top = newSize
 			}
 
 			if (proto.IsVarArg & VarArgIsVarArg) == 0 {
 				if nargs < int(proto.NumUsedRegisters) {
 					nargs = int(proto.NumUsedRegisters)
 				}
-				newSize = cf.LocalBase + nargs
+				newSize := cf.LocalBase + nargs
 				// this section is inlined by go-inline
 				// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
 				{

--- a/vm.go
+++ b/vm.go
@@ -728,26 +728,30 @@ func init() {
 						proto := cf.Fn.Proto
 						nargs := cf.NArgs
 						np := int(proto.NumParameters)
-						newSize := cf.LocalBase + np
-						// this section is inlined by go-inline
-						// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
-						{
-							rg := ls.reg
-							requiredSize := newSize
-							if requiredSize > cap(rg.array) {
-								rg.resize(requiredSize)
+						if nargs < np {
+							// default any missing arguments to nil
+							newSize := cf.LocalBase + np
+							// this section is inlined by go-inline
+							// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+							{
+								rg := ls.reg
+								requiredSize := newSize
+								if requiredSize > cap(rg.array) {
+									rg.resize(requiredSize)
+								}
 							}
-						}
-						for i := nargs; i < np; i++ {
-							ls.reg.array[cf.LocalBase+i] = LNil
+							for i := nargs; i < np; i++ {
+								ls.reg.array[cf.LocalBase+i] = LNil
+							}
 							nargs = np
+							ls.reg.top = newSize
 						}
 
 						if (proto.IsVarArg & VarArgIsVarArg) == 0 {
 							if nargs < int(proto.NumUsedRegisters) {
 								nargs = int(proto.NumUsedRegisters)
 							}
-							newSize = cf.LocalBase + nargs
+							newSize := cf.LocalBase + nargs
 							// this section is inlined by go-inline
 							// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
 							{
@@ -906,26 +910,30 @@ func init() {
 						proto := cf.Fn.Proto
 						nargs := cf.NArgs
 						np := int(proto.NumParameters)
-						newSize := cf.LocalBase + np
-						// this section is inlined by go-inline
-						// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
-						{
-							rg := ls.reg
-							requiredSize := newSize
-							if requiredSize > cap(rg.array) {
-								rg.resize(requiredSize)
+						if nargs < np {
+							// default any missing arguments to nil
+							newSize := cf.LocalBase + np
+							// this section is inlined by go-inline
+							// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
+							{
+								rg := ls.reg
+								requiredSize := newSize
+								if requiredSize > cap(rg.array) {
+									rg.resize(requiredSize)
+								}
 							}
-						}
-						for i := nargs; i < np; i++ {
-							ls.reg.array[cf.LocalBase+i] = LNil
+							for i := nargs; i < np; i++ {
+								ls.reg.array[cf.LocalBase+i] = LNil
+							}
 							nargs = np
+							ls.reg.top = newSize
 						}
 
 						if (proto.IsVarArg & VarArgIsVarArg) == 0 {
 							if nargs < int(proto.NumUsedRegisters) {
 								nargs = int(proto.NumUsedRegisters)
 							}
-							newSize = cf.LocalBase + nargs
+							newSize := cf.LocalBase + nargs
 							// this section is inlined by go-inline
 							// source function is 'func (rg *registry) checkSize(requiredSize int) ' in '_state.go'
 							{


### PR DESCRIPTION
Fixes # (no issue created).

Changes proposed in this pull request:

- This fixes a panic which could occur in `initCallFrame` which was introduced when I added my auto resizing registry implementation a couple of years back
- The panic would happen due to `initCallFrame` filling out missing arguments beyond "top" and then calling `resize` to allocate local variable space, which would then discard the defaulted arguments
- The discarded defaulted arguments would then end up as the go lang `nil` value, which would then later panic when they were interpreted as `LValue`
- The panic was very rare, as it seems that most times a registry resize did not happen in combination with defaulting some arguments
- There are two commits, 1 to create a test to show the panic, and another to fix the panic
- The only changes are to `_state.go`, all the other files are just knock ons from the fix being copied by go-inline