### PR TITLE
Iterate from start of array to match Lua 5.1 `#` operator behavior.

### DIFF
--- a/_glua-tests/issues.lua
+++ b/_glua-tests/issues.lua
@@ -331,3 +331,20 @@ function test()
 	assert(os.time(t1) == os.time(t6))
 end
 test()
+-- issue #304
+do
+	local x ={
+		[20] = 0;
+		[600] = 0;
+	}
+	local y = {
+		"a", "b", "c"
+	}
+	assert(#x == 0)
+	assert(#y == 3)
+	local a = {}
+	for i=1,100 do
+	  a[i] = true
+	  assert(#a == i)
+	end
+end

--- a/table.go
+++ b/table.go
@@ -51,13 +51,14 @@ func (tb *LTable) Len() int {
 	if tb.array == nil {
 		return 0
 	}
-	var prev LValue = LNil
-	for i := len(tb.array) - 1; i >= 0; i-- {
+	for i := 0; i < len(tb.array); i++ {
 		v := tb.array[i]
-		if prev == LNil && v != LNil {
-			return i + 1
+		x := i + 1
+		if len(tb.array) == x && v != LNil {
+			return x
+		} else if v == LNil {
+			break
 		}
-		prev = v
 	}
 	return 0
 }


### PR DESCRIPTION
Fixes #304 

Changes proposed in this pull request:

Follow behavior of Lua 5.1 `#` operator.