### PR TITLE
ExecutionLimit option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -239,6 +239,8 @@ Miscellaneous lua.NewState options
 - **Options.IncludeGoStackTrace bool(default false)**
     - By default, GopherLua does not show Go stack traces when panics occur.
     - You can get Go stack traces by setting this to ``true`` .
+- **Options.ExecutionLimit uint(default 0)**
+    - Sets the maximum number of operations to execute. A value of ``0`` indicates no limit.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 API

--- a/_state.go
+++ b/_state.go
@@ -105,6 +105,8 @@ type Options struct {
 	// If `MinimizeStackMemory` is set, the call stack will be automatically grown or shrank up to a limit of
 	// `CallStackSize` in order to minimize memory usage. This does incur a slight performance penalty.
 	MinimizeStackMemory bool
+	// Sets the maximum number of operations to execute. A value of 0 indicates no limit.
+	ExecutionLimit uint
 }
 
 /* }}} */
@@ -621,6 +623,15 @@ func (ls *LState) printCallStack() {
 		}
 	}
 	println("-------------------------")
+}
+
+func (ls *LState) incOpCounter() {
+	if ls.Options.ExecutionLimit > 0 {
+		ls.G.opcount++
+		if ls.G.opcount > ls.Options.ExecutionLimit {
+			ls.RaiseError("execution limit reached")
+		}
+	}
 }
 
 func (ls *LState) closeAllUpvalues() { // +inline-start

--- a/_vm.go
+++ b/_vm.go
@@ -24,6 +24,7 @@ func mainLoop(L *LState, baseframe *callFrame) {
 		cf = L.currentFrame
 		inst = cf.Fn.Proto.Code[cf.Pc]
 		cf.Pc++
+		L.incOpCounter()
 		if jumpTable[int(inst>>26)](L, inst, baseframe) == 1 {
 			return
 		}
@@ -53,6 +54,7 @@ func mainLoopWithContext(L *LState, baseframe *callFrame) {
 			L.RaiseError(L.ctx.Err().Error())
 			return
 		default:
+			L.incOpCounter()
 			if jumpTable[int(inst>>26)](L, inst, baseframe) == 1 {
 				return
 			}

--- a/state.go
+++ b/state.go
@@ -109,6 +109,8 @@ type Options struct {
 	// If `MinimizeStackMemory` is set, the call stack will be automatically grown or shrank up to a limit of
 	// `CallStackSize` in order to minimize memory usage. This does incur a slight performance penalty.
 	MinimizeStackMemory bool
+	// Sets the maximum number of operations to execute. A value of 0 indicates no limit.
+	ExecutionLimit uint
 }
 
 /* }}} */
@@ -667,6 +669,15 @@ func (ls *LState) printCallStack() {
 		}
 	}
 	println("-------------------------")
+}
+
+func (ls *LState) incOpCounter() {
+	if ls.Options.ExecutionLimit > 0 {
+		ls.G.opcount++
+		if ls.G.opcount > ls.Options.ExecutionLimit {
+			ls.RaiseError("execution limit reached")
+		}
+	}
 }
 
 func (ls *LState) closeAllUpvalues() { // +inline-start

--- a/state_test.go
+++ b/state_test.go
@@ -560,6 +560,107 @@ func TestUninitializedVarAccess(t *testing.T) {
 	`)
 }
 
+func TestExecutionLimit(t *testing.T) {
+	code := `
+		local function test(count)
+			for i=0,count do
+				print(i)
+			end
+		end
+		test(100)
+	`
+	L := NewState(Options{ExecutionLimit: 400})
+	defer L.Close()
+	errorIfScriptNotFail(t, L, code, "execution limit reached")
+
+	L2 := NewState(Options{ExecutionLimit: 500})
+	defer L2.Close()
+	errorIfScriptFail(t, L2, code)
+}
+
+func TestExecutionLimitWithContext(t *testing.T) {
+	code := `
+		local function test(count)
+			for i=0,count do
+				print(i)
+			end
+		end
+		test(100)
+	`
+	L := NewState(Options{ExecutionLimit: 400})
+	defer L.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	L.SetContext(ctx)
+	errorIfScriptNotFail(t, L, code, "execution limit reached")
+
+	L2 := NewState(Options{ExecutionLimit: 500})
+	defer L2.Close()
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel2()
+	L2.SetContext(ctx2)
+	errorIfScriptFail(t, L2, code)
+}
+
+func TestExecutionLimitCoroutineApi(t *testing.T) {
+	L := NewState(Options{ExecutionLimit: 100})
+	defer L.Close()
+	co, _ := L.NewThread()
+	errorIfScriptFail(t, L, `
+		function coro(x)
+			repeat
+				x = coroutine.yield(0)
+			until x > 0
+			return x
+		end
+    `)
+	fn := L.GetGlobal("coro").(*LFunction)
+
+	for i := 0; i < 14; i++ {
+		st, err, values := L.Resume(co, fn, LNumber(0))
+		errorIfNotNil(t, err)
+		errorIfNotEqual(t, ResumeYield, st)
+		errorIfNotEqual(t, 1, len(values))
+		errorIfNotEqual(t, LNumber(0), values[0].(LNumber))
+	}
+	st, err, _ := L.Resume(co, fn, LNumber(0))
+	errorIfFalse(t, err.Error() != "execution limit reached", "expected execution limit reached exception, got "+err.Error())
+	errorIfNotEqual(t, ResumeError, st)
+}
+
+func benchmarkExecutionLimit(limit bool, b *testing.B) {
+	var L *LState
+	if limit {
+		L = NewState(Options{ExecutionLimit: ^uint(0)})
+	} else {
+		L = NewState()
+	}
+	defer L.Close()
+
+	b.ResetTimer()
+	for j := 0; j < b.N; j++ {
+		err := L.DoString(`
+			local function test(count)
+				local j = 0
+				for i=0,count do
+					j = j + 1
+				end
+			end
+			test(100)
+		`)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkExecutionLimit(b *testing.B) {
+	benchmarkExecutionLimit(true, b)
+}
+func BenchmarkNoExecutionLimit(b *testing.B) {
+	benchmarkExecutionLimit(false, b)
+}
+
 func BenchmarkCallFrameStackPushPopAutoGrow(t *testing.B) {
 	stack := newAutoGrowingCallFrameStack(256)
 

--- a/value.go
+++ b/value.go
@@ -198,6 +198,7 @@ type Global struct {
 	builtinMts map[int]LValue
 	tempFiles  []*os.File
 	gccount    int32
+	opcount    uint
 }
 
 type LState struct {

--- a/vm.go
+++ b/vm.go
@@ -28,6 +28,7 @@ func mainLoop(L *LState, baseframe *callFrame) {
 		cf = L.currentFrame
 		inst = cf.Fn.Proto.Code[cf.Pc]
 		cf.Pc++
+		L.incOpCounter()
 		if jumpTable[int(inst>>26)](L, inst, baseframe) == 1 {
 			return
 		}
@@ -57,6 +58,7 @@ func mainLoopWithContext(L *LState, baseframe *callFrame) {
 			L.RaiseError(L.ctx.Err().Error())
 			return
 		default:
+			L.incOpCounter()
 			if jumpTable[int(inst>>26)](L, inst, baseframe) == 1 {
 				return
 			}


### PR DESCRIPTION
Fixes # (no issue created).

Changes proposed in this pull request:

- A new lua.NewState option `ExecutionLimit uint`. Sets the maximum number of operations to execute. A value of `0` (default) indicates no limit.
