### PR TITLE
Convert int to string using rune() in lexer.go

### DIFF
--- a/parse/lexer.go
+++ b/parse/lexer.go
@@ -255,7 +255,7 @@ func (sc *Scanner) scanMultilineString(ch int, buf *bytes.Buffer) error {
 	var count1, count2 int
 	count1, ch = sc.countSep(ch)
 	if ch != '[' {
-		return sc.Error(string(ch), "invalid multiline string")
+		return sc.Error(string(rune(ch)), "invalid multiline string")
 	}
 	ch = sc.Next()
 	if ch == '\n' || ch == '\r' {
@@ -338,7 +338,7 @@ redo:
 				goto redo
 			} else {
 				tok.Type = ch
-				tok.Str = string(ch)
+				tok.Str = string(rune(ch))
 			}
 		case '"', '\'':
 			tok.Type = TString
@@ -351,7 +351,7 @@ redo:
 				tok.Str = buf.String()
 			} else {
 				tok.Type = ch
-				tok.Str = string(ch)
+				tok.Str = string(rune(ch))
 			}
 		case '=':
 			if sc.Peek() == '=' {
@@ -360,7 +360,7 @@ redo:
 				sc.Next()
 			} else {
 				tok.Type = ch
-				tok.Str = string(ch)
+				tok.Str = string(rune(ch))
 			}
 		case '~':
 			if sc.Peek() == '=' {
@@ -377,7 +377,7 @@ redo:
 				sc.Next()
 			} else {
 				tok.Type = ch
-				tok.Str = string(ch)
+				tok.Str = string(rune(ch))
 			}
 		case '>':
 			if sc.Peek() == '=' {
@@ -386,7 +386,7 @@ redo:
 				sc.Next()
 			} else {
 				tok.Type = ch
-				tok.Str = string(ch)
+				tok.Str = string(rune(ch))
 			}
 		case '.':
 			ch2 := sc.Peek()
@@ -410,7 +410,7 @@ redo:
 			tok.Str = buf.String()
 		case '+', '*', '/', '%', '^', '#', '(', ')', '{', '}', ']', ';', ':', ',':
 			tok.Type = ch
-			tok.Str = string(ch)
+			tok.Str = string(rune(ch))
 		default:
 			writeChar(buf, ch)
 			err = sc.Error(buf.String(), "Invalid token")


### PR DESCRIPTION
This is the same issue as #298 but for lexer.go.
It seems the issue only popped up since Go 1.18.