### PR TITLE
add package.config

### DIFF
--- a/config.go
+++ b/config.go
@@ -22,15 +22,22 @@ var LuaPath = "LUA_PATH"
 var LuaLDir string
 var LuaPathDefault string
 var LuaOS string
+var LuaDirSep string
+var LuaPathSep = ";"
+var LuaPathMark = "?"
+var LuaExecDir = "!"
+var LuaIgMark = "-"
 
 func init() {
 	if os.PathSeparator == '/' { // unix-like
 		LuaOS = "unix"
 		LuaLDir = "/usr/local/share/lua/5.1"
+		LuaDirSep = "/"
 		LuaPathDefault = "./?.lua;" + LuaLDir + "/?.lua;" + LuaLDir + "/?/init.lua"
 	} else { // windows
 		LuaOS = "windows"
 		LuaLDir = "!\\lua"
+		LuaDirSep = "\\"
 		LuaPathDefault = ".\\?.lua;" + LuaLDir + "\\?.lua;" + LuaLDir + "\\?\\init.lua"
 	}
 }

--- a/loadlib.go
+++ b/loadlib.go
@@ -65,6 +65,9 @@ func OpenPackage(L *LState) int {
 	L.SetField(packagemod, "path", LString(loGetPath(LuaPath, LuaPathDefault)))
 	L.SetField(packagemod, "cpath", emptyLString)
 
+	L.SetField(packagemod, "config", LString(LuaDirSep+"\n"+LuaPathSep+
+		"\n"+LuaPathMark+"\n"+LuaExecDir+"\n"+LuaIgMark+"\n"))
+
 	L.Push(packagemod)
 	return 1
 }


### PR DESCRIPTION
package.config was added in Lua v5.0-430-gab3dfa55.
https://github.com/lua/lua/commit/ab3dfa55948a670c35152ffd965d218ad48f871a

but was documented since version 5.2
https://www.lua.org/manual/5.2/manual.html#pdf-package.config

Lua 5.1.5  Copyright (C) 1994-2012 Lua.org, PUC-Rio
> print(package.config)
/
;
?
!
-
>

In gopher-lua package.config is nil.
This causes some packages, such as Luarocks, to crash with an error.

CLoses #360

