### PR TITLE
Fix the popen with "w" by closing the writer (otherwise wait never terminates)

### DIFF
--- a/iolib.go
+++ b/iolib.go
@@ -278,8 +278,13 @@ func fileCloseAux(L *LState, file *lFile) int {
 		L.Push(LTrue)
 		return 1
 	case lFileProcess:
-		if file.stdout != nil {
-			file.stdout.Close() // ignore errors
+		// When stdout is piped, close it
+		if closer, ok := file.stdout.(io.Closer); ok {
+			_ = closer.Close() // ignore errors
+		}
+		// When stdin is piped, close it
+		if closer, ok := file.writer.(io.Closer); ok {
+			_ = closer.Close() // ignore errors
 		}
 		err = file.pp.Wait()
 		var exitStatus int // Initialised to zero value = 0

--- a/iolib_test.go
+++ b/iolib_test.go
@@ -1,0 +1,55 @@
+package lua
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestWriter(t *testing.T) {
+	L := NewState()
+	defer L.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	doneCh := make(chan int, 1)
+
+	go func() {
+		defer close(doneCh)
+		errorIfScriptFail(t, L, `f, err = io.popen('cat', 'w'); assert(not err, err); f:write("hello"); f:close()`)
+	}()
+
+	select {
+	case <-doneCh:
+		//	Success
+	case <-ctx.Done():
+		if err := ctx.Err(); err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+func TestReader(t *testing.T) {
+	L := NewState()
+	defer L.Close()
+
+	t.Run("should pass", func(t *testing.T) {
+		errorIfScriptFail(t, L, `
+			f, err = io.popen('echo "foo"', 'r')
+			assert(not err, err)
+			data, err = f:read('*a')
+			assert(not err, err)
+			rc = f:close()
+			assert(rc == 0, tostring(rc))
+			assert(data == "foo\n", data)
+		`)
+	})
+
+	t.Run("should fail", func(t *testing.T) {
+		errorIfScriptFail(t, L, `
+			f, err = io.popen('false')
+			assert(not err, err)
+			rc = f:close()
+			assert(rc ~= 0, tostring(rc))
+		`)
+	})
+}

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -14,12 +14,14 @@ func positionString(level int) string {
 }
 
 func errorIfNotEqual(t *testing.T, v1, v2 interface{}) {
+	t.Helper()
 	if v1 != v2 {
 		t.Errorf("%v '%v' expected, but got '%v'", positionString(1), v1, v2)
 	}
 }
 
 func errorIfFalse(t *testing.T, cond bool, msg string, args ...interface{}) {
+	t.Helper()
 	if !cond {
 		if len(args) > 0 {
 			t.Errorf("%v %v", positionString(1), fmt.Sprintf(msg, args...))
@@ -30,30 +32,35 @@ func errorIfFalse(t *testing.T, cond bool, msg string, args ...interface{}) {
 }
 
 func errorIfNotNil(t *testing.T, v1 interface{}) {
+	t.Helper()
 	if fmt.Sprint(v1) != "<nil>" {
 		t.Errorf("%v nil expected, but got '%v'", positionString(1), v1)
 	}
 }
 
 func errorIfNil(t *testing.T, v1 interface{}) {
+	t.Helper()
 	if fmt.Sprint(v1) == "<nil>" {
 		t.Errorf("%v non-nil value expected, but got nil", positionString(1))
 	}
 }
 
 func errorIfScriptFail(t *testing.T, L *LState, script string) {
+	t.Helper()
 	if err := L.DoString(script); err != nil {
 		t.Errorf("%v %v", positionString(1), err.Error())
 	}
 }
 
 func errorIfGFuncFail(t *testing.T, L *LState, f LGFunction) {
+	t.Helper()
 	if err := L.GPCall(f, LNil); err != nil {
 		t.Errorf("%v %v", positionString(1), err.Error())
 	}
 }
 
 func errorIfScriptNotFail(t *testing.T, L *LState, script string, pattern string) {
+	t.Helper()
 	if err := L.DoString(script); err != nil {
 		reg := regexp.MustCompile(pattern)
 		if len(reg.FindStringIndex(err.Error())) == 0 {
@@ -66,6 +73,7 @@ func errorIfScriptNotFail(t *testing.T, L *LState, script string, pattern string
 }
 
 func errorIfGFuncNotFail(t *testing.T, L *LState, f LGFunction, pattern string) {
+	t.Helper()
 	if err := L.GPCall(f, LNil); err != nil {
 		reg := regexp.MustCompile(pattern)
 		if len(reg.FindStringIndex(err.Error())) == 0 {


### PR DESCRIPTION
Changes proposed in this pull request:

- When closing a `lFileProcess` close the writer before calling `Wait`
- Normalize the stdout closing to also use casting to `.(io.Closer)`
- Add a test for read and write