### PR TITLE
Issue #417: support nil params on os.date()

### DIFF
--- a/_glua-tests/issues.lua
+++ b/_glua-tests/issues.lua
@@ -404,3 +404,15 @@ function test()
     assert(2 % 2 == 0)
 end
 test()
+
+-- issue #417
+function test()
+    assert(type(os.date(nil)) == "string")
+    assert(type(os.date(nil, nil)) == "string")  
+    local t = os.time()
+    assert(os.date(nil, t) == os.date("%c", t))
+    assert(os.date(2) == "2")
+    local ok, msg = pcall(os.date, {})
+    assert(not ok and string.find(msg, "string expected, got table", 1, true))
+end
+test()

--- a/oslib.go
+++ b/oslib.go
@@ -108,13 +108,18 @@ func osDate(L *LState) int {
 	t := time.Now()
 	cfmt := "%c"
 	if L.GetTop() >= 1 {
-		cfmt = L.CheckString(1)
+		lv := L.Get(1)
+		if LVCanConvToString(lv) {
+			cfmt = lv.String()
+		} else if lv != LNil {
+			L.TypeError(1, LTString)
+		}
 		if strings.HasPrefix(cfmt, "!") {
 			t = time.Now().UTC()
 			cfmt = strings.TrimLeft(cfmt, "!")
 		}
 		if L.GetTop() >= 2 {
-			t = time.Unix(L.CheckInt64(2), 0)
+			t = time.Unix(L.OptInt64(2, t.Unix()), 0)
 		}
 		if strings.HasPrefix(cfmt, "*t") {
 			ret := L.NewTable()


### PR DESCRIPTION
Fixes #417 .

Changes proposed in this pull request:

- nil params passed to os.date are interpreted as the default values

couldn't use `L.OptString` because unlike `L.CheckString`, it does not convert numbers to strings and lua allows `os.date(2) = "2"`
