### PR TITLE
Supress expected error output

### DIFF
--- a/_glua-tests/os.lua
+++ b/_glua-tests/os.lua
@@ -6,7 +6,7 @@ end
 if osname == "linux" then
   -- travis ci failed to start date command?
   -- assert(os.execute("date") == 0)
-  assert(os.execute("date -a") == 1)
+  assert(os.execute("date -a 2>/dev/null") == 1)
 else
   assert(os.execute("date /T") == 0)
   assert(os.execute("md") == 1)


### PR DESCRIPTION
Fixes confusing output from os.lua test

Changes proposed in this pull request:

- suppress stderr from `date` which doesn't take `-a` (which is flag available on Solaris/AIX).