### PR TITLE
Fix xpcall error in error handler

### DIFF
--- a/_glua-tests/issues.lua
+++ b/_glua-tests/issues.lua
@@ -457,3 +457,14 @@ function test()
   assert(c == 1)
   assert(type(c) == "number")
 end
+
+-- issue #452
+function test()
+  local ok, msg = pcall(function()
+    local ok, msg = xpcall(function() error("fn") end, function(err) error("handler") end)
+    assert(not ok and msg)
+    error("expected to reach this.")
+  end)
+  assert(not ok)
+end
+test()

--- a/_glua-tests/issues.lua
+++ b/_glua-tests/issues.lua
@@ -457,6 +457,7 @@ function test()
   assert(c == 1)
   assert(type(c) == "number")
 end
+test()
 
 -- issue #452
 function test()

--- a/_state.go
+++ b/_state.go
@@ -1855,6 +1855,9 @@ func (ls *LState) PCall(nargs, nret int, errfunc *LFunction) (err error) {
 							err = rcv.(*ApiError)
 							err.(*ApiError).StackTrace = ls.stackTrace(0)
 						}
+						ls.stack.SetSp(sp)
+						ls.currentFrame = ls.stack.Last()
+						ls.reg.SetTop(base)
 					}
 				}()
 				ls.Call(1, 1)

--- a/state.go
+++ b/state.go
@@ -2014,6 +2014,9 @@ func (ls *LState) PCall(nargs, nret int, errfunc *LFunction) (err error) {
 							err = rcv.(*ApiError)
 							err.(*ApiError).StackTrace = ls.stackTrace(0)
 						}
+						ls.stack.SetSp(sp)
+						ls.currentFrame = ls.stack.Last()
+						ls.reg.SetTop(base)
 					}
 				}()
 				ls.Call(1, 1)


### PR DESCRIPTION
Fixes #452 .

Changes proposed in this pull request:

- `xpcall` with error in error handler returns `(false, error-object)`
- Revert back call stack in case of error in error handler for `LState#PCall` 