### PR TITLE
iolib: fix different behavior in read function

### DIFF
--- a/_glua-tests/issues.lua
+++ b/_glua-tests/issues.lua
@@ -470,6 +470,16 @@ function test()
 end
 test()
 
+-- issue #455
+function test()
+  local path = "."
+  local fd, _, code = io.open(path, "r")
+  assert(fd ~= nil)
+  local _, _, ecode = fd:read(1)
+  assert(ecode == 1)
+end
+test()
+
 -- issue #459
 function test()
   local a, b = io.popen("ls", nil)

--- a/iolib.go
+++ b/iolib.go
@@ -404,10 +404,10 @@ normalreturn:
 	return L.GetTop() - top
 
 errreturn:
-	L.RaiseError(err.Error())
-	//L.Push(LNil)
-	//L.Push(LString(err.Error()))
-	return 2
+	L.Push(LNil)
+	L.Push(LString(err.Error()))
+	L.Push(LNumber(1)) // C-Lua compatibility: Original Lua pushes errno to the stack
+	return 3
 }
 
 var fileSeekOptions = []string{"set", "cur", "end"}


### PR DESCRIPTION
$ lua
Lua 5.1.5  Copyright (C) 1994-2012 Lua.org, PUC-Rio
> file = "/tmp"
> fd, _, code = io.open(file, "r")
> _, _, ecode = fd:read(1)
> print(ecode)
21
>

gopher-lua throws an exception:
        read /tmp: is a directory
stack traceback:
        [G]: in function 'read'
        extra/wrapper.lua:17: in function 'exec'
        <string>:1: in main chunk
        [G]: ?

This patch results in behavior similar to the vanilla lua implementation.

Closes #455
