### PR TITLE
popen: support nil in second argument

### DIFF
--- a/_glua-tests/issues.lua
+++ b/_glua-tests/issues.lua
@@ -457,3 +457,14 @@ function test()
   assert(c == 1)
   assert(type(c) == "number")
 end
+
+-- issue #459
+function test()
+  local a, b = io.popen("ls", nil)
+  assert(a)
+  assert(b == nil)
+  local a, b = io.popen("ls", nil, nil)
+  assert(a)
+  assert(b == nil)
+end
+test()

--- a/iolib.go
+++ b/iolib.go
@@ -658,6 +658,9 @@ func ioPopen(L *LState) int {
 	cmd := L.CheckString(1)
 	if L.GetTop() == 1 {
 		L.Push(LString("r"))
+	} else if L.GetTop() > 1 && (L.Get(2)).Type() == LTNil {
+		L.SetTop(1)
+		L.Push(LString("r"))
 	}
 	var file *LUserData
 	var err error


### PR DESCRIPTION
In the C implementation of the Lua interpreter,
in the io.popen function the second argument can be nil:

Lua 5.1.5 Copyright (C) 1994-2012 Lua.org, PUC-Rio:

> x,y = io.popen("ls", nil)
> assert(x)
> assert(y == nil)
>

Gopher lua throws an exception:
bad argument #2 to popen (string expected, got nil)

Closes #459