### PR TITLE
Return a closure without arguments in gfind

### DIFF
--- a/_glua-tests/issues.lua
+++ b/_glua-tests/issues.lua
@@ -490,3 +490,18 @@ function test()
   assert(b == nil)
 end
 test()
+
+-- issue #462
+function test()
+  local x = string.gmatch("asdf", "a")
+  assert(x() == "a", "check gmatch callback")
+
+  local expected = {
+    "a",
+    "c",
+  }
+  for i in string.gmatch("abc", "[ac]") do
+    assert(i == table.remove(expected, 1), "check gmatch inside loop")
+  end
+end
+test()

--- a/stringlib.go
+++ b/stringlib.go
@@ -14,7 +14,7 @@ func OpenString(L *LState) int {
 	//_, ok := L.G.builtinMts[int(LTString)]
 	//if !ok {
 	mod = L.RegisterModule(StringLibName, strFuncs).(*LTable)
-	gmatch := L.NewClosure(strGmatch, L.NewFunction(strGmatchIter))
+	gmatch := L.NewFunction(strGmatch)
 	mod.RawSetString("gmatch", gmatch)
 	mod.RawSetString("gfind", gmatch)
 	mod.RawSetString("__index", mod)
@@ -299,7 +299,7 @@ type strMatchData struct {
 }
 
 func strGmatchIter(L *LState) int {
-	md := L.CheckUserData(1).Value.(*strMatchData)
+	md := L.CheckUserData(UpvalueIndex(1)).Value.(*strMatchData)
 	str := md.str
 	matches := md.matches
 	idx := md.pos
@@ -331,11 +331,11 @@ func strGmatch(L *LState) int {
 	if err != nil {
 		L.RaiseError(err.Error())
 	}
-	L.Push(L.Get(UpvalueIndex(1)))
 	ud := L.NewUserData()
 	ud.Value = &strMatchData{str, 0, mds}
-	L.Push(ud)
-	return 2
+	f := L.NewClosure(strGmatchIter, ud)
+	L.Push(f)
+	return 1
 }
 
 func strLen(L *LState) int {


### PR DESCRIPTION
Fixes #462.

In https://www.lua.org/manual/5.1/manual.html#pdf-string.gmatch is written for `gmatch`:
> Returns an iterator function that, each time it is called, returns the next captures from pattern over string s. If pattern specifies no captures, then the whole match is produced in each call. 

For `gfind` is written ([which is a deprecated name for `gmatch`](https://www.lua.org/manual/5.1/manual.html#7.2)):
> The gfind function fits perfectly with the generic for loop. It returns a function that iterates on all occurrences of a pattern in a string.

Before this change only first sentence worked. But uses a stateless iterator which gets the state from the for loop. With the change for each call a new closure is created which contains the `gmatch` state. So now direct calls and the for loop works.