### PR TITLE
Bugfix/xpcall number args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+/glua

--- a/_glua-tests/issues.lua
+++ b/_glua-tests/issues.lua
@@ -490,3 +490,22 @@ function test()
   assert(b == nil)
 end
 test()
+
+-- issue #464
+function test()
+  local result = nil
+  local result_err = nil
+  local callback = function(arg)
+    result = arg
+  end
+  local errfunc = function(err)
+    result_err = err
+  end
+  xpcall(callback, errfunc, 9)
+
+  -- check first for error because otherwise also wrong result assert
+  -- would be triggered
+  assert(result_err == nil)
+  assert(result == 9)
+end
+test()

--- a/baselib.go
+++ b/baselib.go
@@ -458,12 +458,11 @@ func baseUnpack(L *LState) int {
 }
 
 func baseXPCall(L *LState) int {
-	fn := L.CheckFunction(1)
 	errfunc := L.CheckFunction(2)
-
+	L.Remove(2)
 	top := L.GetTop()
-	L.Push(fn)
-	if err := L.PCall(0, MultRet, errfunc); err != nil {
+	nargs := top - 1
+	if err := L.PCall(nargs, MultRet, errfunc); err != nil {
 		L.Push(LFalse)
 		if aerr, ok := err.(*ApiError); ok {
 			L.Push(aerr.Object)
@@ -472,8 +471,8 @@ func baseXPCall(L *LState) int {
 		}
 		return 2
 	} else {
-		L.Insert(LTrue, top+1)
-		return L.GetTop() - top
+		L.Insert(LTrue, 1)
+		return L.GetTop()
 	}
 }
 

--- a/cmd/glua/.gitignore
+++ b/cmd/glua/.gitignore
@@ -1,0 +1,2 @@
+/__debug_bin*
+/glua


### PR DESCRIPTION
Fixes #464.

Pass function arguments. Previously the function was called always with zero arguments.