### PR TITLE
Issue #472: tonumber does not handle E notation correctly

### DIFF
--- a/_lua5.1-tests/math.lua
+++ b/_lua5.1-tests/math.lua
@@ -33,6 +33,8 @@ assert(tonumber'+ 0.01' == nil and tonumber'+.e1' == nil and
        tonumber'.' == nil)
 assert(tonumber('-12') == -10-2)
 assert(tonumber('-1.2e2') == - - -120)
+assert(tonumber('2e2') == 200)
+assert(tonumber('2e2', 15) == 662)
 assert(f(tonumber('1  a')) == nil)
 assert(f(tonumber('e1')) == nil)
 assert(f(tonumber('e  1')) == nil)

--- a/baselib.go
+++ b/baselib.go
@@ -410,7 +410,7 @@ func baseToNumber(L *LState) int {
 		L.Push(lv)
 	case LString:
 		str := strings.Trim(string(lv), " \n\t")
-		if strings.Index(str, ".") > -1 {
+		if base == 10 && strings.ContainsAny(str, ".eE") {
 			if v, err := strconv.ParseFloat(str, LNumberBit); err != nil {
 				L.Push(LNil)
 			} else {


### PR DESCRIPTION
Fixes #472 

Changes proposed in this pull request:
- Whenever the base == 10, parse the string as float when it contains `.`, `e`, or `E`.