### PR TITLE
fix: return value error for CompileLua example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -595,7 +595,10 @@ Sharing byte code is safe as it is read only and cannot be altered by lua script
 
     // Example shows how to share the compiled byte code from a lua script between multiple VMs.
     func Example() {
-        codeToShare := CompileLua("mylua.lua")
+        codeToShare, err := CompileLua("mylua.lua")
+        if err != nil {
+            panic(err)
+        }
         a := lua.NewState()
         b := lua.NewState()
         c := lua.NewState()


### PR DESCRIPTION
Fixes # .
Just fix a show-case error about `CompileLua`
The example in [Sharing Lua byte code between LStates](https://github.com/yuin/gopher-lua/?tab=readme-ov-file#sharing-lua-byte-code-between-lstates),
CompileLua function return two values, but when invoke CompileLua only use one return value
![image](https://github.com/user-attachments/assets/85e03bb0-9e1a-4063-a1d2-5ae5bbbdf3c5)

Changes proposed in this pull request:

- a
- b
- c
- d
