### PR TITLE
Remove io/ioutil usages (deprecated since Go 1.16)

### DIFF
--- a/auxlib_test.go
+++ b/auxlib_test.go
@@ -1,7 +1,6 @@
 package lua
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -300,10 +299,10 @@ func TestOptChannel(t *testing.T) {
 }
 
 func TestLoadFileForShebang(t *testing.T) {
-	tmpFile, err := ioutil.TempFile("", "")
+	tmpFile, err := os.CreateTemp("", "")
 	errorIfNotNil(t, err)
 
-	err = ioutil.WriteFile(tmpFile.Name(), []byte(`#!/path/to/lua
+	err = os.WriteFile(tmpFile.Name(), []byte(`#!/path/to/lua
 print("hello")
 `), 0644)
 	errorIfNotNil(t, err)
@@ -321,7 +320,7 @@ print("hello")
 }
 
 func TestLoadFileForEmptyFile(t *testing.T) {
-	tmpFile, err := ioutil.TempFile("", "")
+	tmpFile, err := os.CreateTemp("", "")
 	errorIfNotNil(t, err)
 
 	defer func() {

--- a/iolib.go
+++ b/iolib.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"syscall"
@@ -373,7 +372,7 @@ func fileReadAux(L *LState, file *lFile, idx int) int {
 					L.Push(v)
 				case 'a':
 					var buf []byte
-					buf, err = ioutil.ReadAll(file.reader)
+					buf, err = io.ReadAll(file.reader)
 					if err == io.EOF {
 						L.Push(emptyLString)
 						goto normalreturn
@@ -704,7 +703,7 @@ func ioType(L *LState) int {
 }
 
 func ioTmpFile(L *LState) int {
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	if err != nil {
 		L.Push(LNil)
 		L.Push(LString(err.Error()))

--- a/oslib.go
+++ b/oslib.go
@@ -1,7 +1,6 @@
 package lua
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -223,7 +222,7 @@ func osTime(L *LState) int {
 }
 
 func osTmpname(L *LState) int {
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	if err != nil {
 		L.RaiseError("unable to generate a unique filename")
 	}


### PR DESCRIPTION
There was no issue addressing this.

Changes proposed in this pull request:

- [io/ioutil](https://pkg.go.dev/io/ioutil) was deprecated on [Go 1.16](https://go.dev/doc/go1.16#ioutil) and I updated the usages to the suggested alternatives.
