### PR TITLE
Run tests in Parallel where possible

### DIFF
--- a/auxlib_test.go
+++ b/auxlib_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestCheckInt(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errorIfGFuncNotFail(t, L, func(L *LState) int {
@@ -19,6 +20,7 @@ func TestCheckInt(t *testing.T) {
 }
 
 func TestCheckInt64(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errorIfGFuncNotFail(t, L, func(L *LState) int {
@@ -31,6 +33,7 @@ func TestCheckInt64(t *testing.T) {
 }
 
 func TestCheckNumber(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errorIfGFuncNotFail(t, L, func(L *LState) int {
@@ -45,6 +48,7 @@ func TestCheckNumber(t *testing.T) {
 }
 
 func TestCheckString(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errorIfGFuncNotFail(t, L, func(L *LState) int {
@@ -59,6 +63,7 @@ func TestCheckString(t *testing.T) {
 }
 
 func TestCheckBool(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errorIfGFuncNotFail(t, L, func(L *LState) int {
@@ -71,6 +76,7 @@ func TestCheckBool(t *testing.T) {
 }
 
 func TestCheckTable(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errorIfGFuncNotFail(t, L, func(L *LState) int {
@@ -84,6 +90,7 @@ func TestCheckTable(t *testing.T) {
 }
 
 func TestCheckFunction(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errorIfGFuncNotFail(t, L, func(L *LState) int {
@@ -97,6 +104,7 @@ func TestCheckFunction(t *testing.T) {
 }
 
 func TestCheckUserData(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errorIfGFuncNotFail(t, L, func(L *LState) int {
@@ -110,6 +118,7 @@ func TestCheckUserData(t *testing.T) {
 }
 
 func TestCheckThread(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errorIfGFuncNotFail(t, L, func(L *LState) int {
@@ -123,6 +132,7 @@ func TestCheckThread(t *testing.T) {
 }
 
 func TestCheckChannel(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errorIfGFuncNotFail(t, L, func(L *LState) int {
@@ -136,6 +146,7 @@ func TestCheckChannel(t *testing.T) {
 }
 
 func TestCheckType(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errorIfGFuncNotFail(t, L, func(L *LState) int {
@@ -147,6 +158,7 @@ func TestCheckType(t *testing.T) {
 }
 
 func TestCheckTypes(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errorIfGFuncNotFail(t, L, func(L *LState) int {
@@ -158,6 +170,7 @@ func TestCheckTypes(t *testing.T) {
 }
 
 func TestCheckOption(t *testing.T) {
+	t.Parallel()
 	opts := []string{
 		"opt1",
 		"opt2",
@@ -175,6 +188,7 @@ func TestCheckOption(t *testing.T) {
 }
 
 func TestOptInt(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errorIfGFuncNotFail(t, L, func(L *LState) int {
@@ -188,6 +202,7 @@ func TestOptInt(t *testing.T) {
 }
 
 func TestOptInt64(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errorIfGFuncNotFail(t, L, func(L *LState) int {
@@ -201,6 +216,7 @@ func TestOptInt64(t *testing.T) {
 }
 
 func TestOptNumber(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errorIfGFuncNotFail(t, L, func(L *LState) int {
@@ -214,6 +230,7 @@ func TestOptNumber(t *testing.T) {
 }
 
 func TestOptString(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errorIfGFuncNotFail(t, L, func(L *LState) int {
@@ -227,6 +244,7 @@ func TestOptString(t *testing.T) {
 }
 
 func TestOptBool(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errorIfGFuncNotFail(t, L, func(L *LState) int {
@@ -240,6 +258,7 @@ func TestOptBool(t *testing.T) {
 }
 
 func TestOptTable(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errorIfGFuncNotFail(t, L, func(L *LState) int {
@@ -255,6 +274,7 @@ func TestOptTable(t *testing.T) {
 }
 
 func TestOptFunction(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errorIfGFuncNotFail(t, L, func(L *LState) int {
@@ -270,6 +290,7 @@ func TestOptFunction(t *testing.T) {
 }
 
 func TestOptUserData(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errorIfGFuncNotFail(t, L, func(L *LState) int {
@@ -285,6 +306,7 @@ func TestOptUserData(t *testing.T) {
 }
 
 func TestOptChannel(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errorIfGFuncNotFail(t, L, func(L *LState) int {
@@ -300,6 +322,7 @@ func TestOptChannel(t *testing.T) {
 }
 
 func TestLoadFileForShebang(t *testing.T) {
+	t.Parallel()
 	tmpFile, err := ioutil.TempFile("", "")
 	errorIfNotNil(t, err)
 
@@ -321,6 +344,7 @@ print("hello")
 }
 
 func TestLoadFileForEmptyFile(t *testing.T) {
+	t.Parallel()
 	tmpFile, err := ioutil.TempFile("", "")
 	errorIfNotNil(t, err)
 

--- a/channellib_test.go
+++ b/channellib_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestChannelMake(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errorIfScriptFail(t, L, `
@@ -30,6 +31,7 @@ func TestChannelMake(t *testing.T) {
 }
 
 func TestChannelSelectError(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errorIfScriptFail(t, L, `ch = channel.make()`)
@@ -42,6 +44,7 @@ func TestChannelSelectError(t *testing.T) {
 }
 
 func TestChannelSelect1(t *testing.T) {
+	t.Parallel()
 	var result LValue
 	var wg sync.WaitGroup
 	receiver := func(ch, quit chan LValue) {
@@ -106,6 +109,7 @@ func TestChannelSelect1(t *testing.T) {
 }
 
 func TestChannelSelect2(t *testing.T) {
+	t.Parallel()
 	var wg sync.WaitGroup
 	receiver := func(ch, quit chan LValue) {
 		defer wg.Done()
@@ -150,6 +154,7 @@ func TestChannelSelect2(t *testing.T) {
 }
 
 func TestChannelSelect3(t *testing.T) {
+	t.Parallel()
 	var wg sync.WaitGroup
 	receiver := func(ch chan LValue) {
 		defer wg.Done()
@@ -196,6 +201,7 @@ func TestChannelSelect3(t *testing.T) {
 }
 
 func TestChannelSelect4(t *testing.T) {
+	t.Parallel()
 	var wg sync.WaitGroup
 	receiver := func(ch chan LValue) {
 		defer wg.Done()
@@ -227,6 +233,7 @@ func TestChannelSelect4(t *testing.T) {
 }
 
 func TestChannelSendReceive1(t *testing.T) {
+	t.Parallel()
 	var wg sync.WaitGroup
 	receiver := func(ch chan LValue) {
 		defer wg.Done()
@@ -262,6 +269,7 @@ func TestChannelSendReceive1(t *testing.T) {
 }
 
 func TestCancelChannelReceive(t *testing.T) {
+	t.Parallel()
 	done := make(chan struct{})
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
@@ -278,6 +286,7 @@ func TestCancelChannelReceive(t *testing.T) {
 }
 
 func TestCancelChannelReceive2(t *testing.T) {
+	t.Parallel()
 	done := make(chan struct{})
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {

--- a/state_test.go
+++ b/state_test.go
@@ -8,12 +8,14 @@ import (
 )
 
 func TestLStateIsClosed(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	L.Close()
 	errorIfNotEqual(t, true, L.IsClosed())
 }
 
 func TestCallStackOverflowWhenFixed(t *testing.T) {
+	t.Parallel()
 	L := NewState(Options{
 		CallStackSize: 3,
 	})
@@ -40,6 +42,7 @@ func TestCallStackOverflowWhenFixed(t *testing.T) {
 }
 
 func TestCallStackOverflowWhenAutoGrow(t *testing.T) {
+	t.Parallel()
 	L := NewState(Options{
 		CallStackSize:       3,
 		MinimizeStackMemory: true,
@@ -67,6 +70,7 @@ func TestCallStackOverflowWhenAutoGrow(t *testing.T) {
 }
 
 func TestSkipOpenLibs(t *testing.T) {
+	t.Parallel()
 	L := NewState(Options{SkipOpenLibs: true})
 	defer L.Close()
 	errorIfScriptNotFail(t, L, `print("")`,
@@ -77,6 +81,7 @@ func TestSkipOpenLibs(t *testing.T) {
 }
 
 func TestGetAndReplace(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	L.Push(LString("a"))
@@ -130,6 +135,7 @@ func TestGetAndReplace(t *testing.T) {
 }
 
 func TestRemove(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	L.Push(LString("a"))
@@ -163,6 +169,7 @@ func TestRemove(t *testing.T) {
 }
 
 func TestToInt(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	L.Push(LNumber(10))
@@ -174,6 +181,7 @@ func TestToInt(t *testing.T) {
 }
 
 func TestToInt64(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	L.Push(LNumber(10))
@@ -185,6 +193,7 @@ func TestToInt64(t *testing.T) {
 }
 
 func TestToNumber(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	L.Push(LNumber(10))
@@ -196,6 +205,7 @@ func TestToNumber(t *testing.T) {
 }
 
 func TestToString(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	L.Push(LNumber(10))
@@ -207,6 +217,7 @@ func TestToString(t *testing.T) {
 }
 
 func TestToTable(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	L.Push(LNumber(10))
@@ -218,6 +229,7 @@ func TestToTable(t *testing.T) {
 }
 
 func TestToFunction(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	L.Push(LNumber(10))
@@ -229,6 +241,7 @@ func TestToFunction(t *testing.T) {
 }
 
 func TestToUserData(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	L.Push(LNumber(10))
@@ -240,6 +253,7 @@ func TestToUserData(t *testing.T) {
 }
 
 func TestToChannel(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	L.Push(LNumber(10))
@@ -252,6 +266,7 @@ func TestToChannel(t *testing.T) {
 }
 
 func TestObjLen(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errorIfNotEqual(t, 3, L.ObjLen(LString("abc")))
@@ -271,12 +286,14 @@ func TestObjLen(t *testing.T) {
 }
 
 func TestConcat(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errorIfNotEqual(t, "a1c", L.Concat(LString("a"), LNumber(1), LString("c")))
 }
 
 func TestPCall(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	L.Register("f1", func(L *LState) int {
@@ -327,6 +344,7 @@ func TestPCall(t *testing.T) {
 }
 
 func TestCoroutineApi1(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	co, _ := L.NewThread()
@@ -399,6 +417,7 @@ func TestCoroutineApi1(t *testing.T) {
 }
 
 func TestContextTimeout(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
@@ -422,6 +441,7 @@ func TestContextTimeout(t *testing.T) {
 }
 
 func TestContextCancel(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -445,6 +465,7 @@ func TestContextCancel(t *testing.T) {
 }
 
 func TestContextWithCroutine(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -475,6 +496,7 @@ func TestContextWithCroutine(t *testing.T) {
 }
 
 func TestPCallAfterFail(t *testing.T) {
+	t.Parallel()
 	L := NewState()
 	defer L.Close()
 	errFn := L.NewFunction(func(L *LState) int {
@@ -495,6 +517,7 @@ func TestPCallAfterFail(t *testing.T) {
 }
 
 func TestRegistryFixedOverflow(t *testing.T) {
+	t.Parallel()
 	state := NewState()
 	defer state.Close()
 	reg := state.reg
@@ -523,6 +546,7 @@ func TestRegistryFixedOverflow(t *testing.T) {
 }
 
 func TestRegistryAutoGrow(t *testing.T) {
+	t.Parallel()
 	state := NewState(Options{RegistryMaxSize: 300, RegistrySize: 200, RegistryGrowStep: 25})
 	defer state.Close()
 	expectedPanic := false
@@ -552,6 +576,7 @@ func TestRegistryAutoGrow(t *testing.T) {
 // directly to the reg's array, but crucially, before it had updated "top". This meant when the resize occurred, the
 // values beyond top where not copied, and were lost, leading to a later uninitialised value being found in the registry.
 func TestUninitializedVarAccess(t *testing.T) {
+	t.Parallel()
 	L := NewState(Options{
 		RegistrySize:    128,
 		RegistryMaxSize: 256,

--- a/table_test.go
+++ b/table_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestTableNewLTable(t *testing.T) {
+	t.Parallel()
 	tbl := newLTable(-1, -2)
 	errorIfNotEqual(t, 0, cap(tbl.array))
 
@@ -13,6 +14,7 @@ func TestTableNewLTable(t *testing.T) {
 }
 
 func TestTableLen(t *testing.T) {
+	t.Parallel()
 	tbl := newLTable(0, 0)
 	tbl.RawSetInt(10, LNil)
 	tbl.RawSetInt(9, LNumber(10))
@@ -28,6 +30,7 @@ func TestTableLen(t *testing.T) {
 }
 
 func TestTableLenType(t *testing.T) {
+	t.Parallel()
 	L := NewState(Options{})
 	err := L.DoString(`
         mt = {
@@ -52,6 +55,7 @@ func TestTableLenType(t *testing.T) {
 }
 
 func TestTableAppend(t *testing.T) {
+	t.Parallel()
 	tbl := newLTable(0, 0)
 	tbl.RawSetInt(1, LNumber(1))
 	tbl.RawSetInt(2, LNumber(2))
@@ -74,6 +78,7 @@ func TestTableAppend(t *testing.T) {
 }
 
 func TestTableInsert(t *testing.T) {
+	t.Parallel()
 	tbl := newLTable(0, 0)
 	tbl.Append(LTrue)
 	tbl.Append(LTrue)
@@ -105,6 +110,7 @@ func TestTableInsert(t *testing.T) {
 }
 
 func TestTableMaxN(t *testing.T) {
+	t.Parallel()
 	tbl := newLTable(0, 0)
 	tbl.Append(LTrue)
 	tbl.Append(LTrue)
@@ -119,6 +125,7 @@ func TestTableMaxN(t *testing.T) {
 }
 
 func TestTableRemove(t *testing.T) {
+	t.Parallel()
 	tbl := newLTable(0, 0)
 	errorIfNotEqual(t, LNil, tbl.Remove(10))
 	tbl.Append(LTrue)
@@ -135,6 +142,7 @@ func TestTableRemove(t *testing.T) {
 }
 
 func TestTableRawSetInt(t *testing.T) {
+	t.Parallel()
 	tbl := newLTable(0, 0)
 	tbl.RawSetInt(MaxArrayIndex+1, LTrue)
 	errorIfNotEqual(t, 0, tbl.MaxN())
@@ -153,6 +161,7 @@ func TestTableRawSetInt(t *testing.T) {
 }
 
 func TestTableRawSetH(t *testing.T) {
+	t.Parallel()
 	tbl := newLTable(0, 0)
 	tbl.RawSetH(LString("key"), LTrue)
 	tbl.RawSetH(LString("key"), LNil)
@@ -166,6 +175,7 @@ func TestTableRawSetH(t *testing.T) {
 }
 
 func TestTableRawGetH(t *testing.T) {
+	t.Parallel()
 	tbl := newLTable(0, 0)
 	errorIfNotEqual(t, LNil, tbl.RawGetH(LNumber(1)))
 	errorIfNotEqual(t, LNil, tbl.RawGetH(LString("key0")))
@@ -179,6 +189,7 @@ func TestTableRawGetH(t *testing.T) {
 }
 
 func TestTableForEach(t *testing.T) {
+	t.Parallel()
 	tbl := newLTable(0, 0)
 	tbl.Append(LNumber(1))
 	tbl.Append(LNumber(2))


### PR DESCRIPTION
There was no issue addressing this.

Changes proposed in this pull request:

- Make most of the tests run in parallel as they are totally independent from one another. Untouched tests (depend on `os`):
  - oslib_test.go (filesystem)
  - baselib_test.go (use `os.Getenv`)
  - script_test.go (use `os.Chdir`)

This change is very noticeable in CI specially when `-race` is enabled and/or running in GitHub Actions (tests can easily take 30+ seconds to run).

Here's some timing information (my local machine):
- Old: 7.674s (avg 12 runs)
- New: 2.669s (avg 12 runs)