### PR TITLE
fix: stack overflow in table.concat function

### DIFF
--- a/tablelib.go
+++ b/tablelib.go
@@ -2,6 +2,7 @@ package lua
 
 import (
 	"sort"
+	"strings"
 )
 
 func OpenTable(L *LState) int {
@@ -66,19 +67,18 @@ func tableConcat(L *LState) int {
 		L.Push(emptyLString)
 		return 1
 	}
-	//TODO should flushing?
-	retbottom := L.GetTop()
+	var sb strings.Builder
 	for ; i <= j; i++ {
 		v := tbl.RawGetInt(i)
 		if !LVCanConvToString(v) {
 			L.RaiseError("invalid value (%s) at index %d in table for concat", v.Type().String(), i)
 		}
-		L.Push(v)
+		sb.WriteString(LVAsString(v))
 		if i != j {
-			L.Push(sep)
+			sb.WriteString(LVAsString(sep))
 		}
 	}
-	L.Push(stringConcat(L, L.GetTop()-retbottom, L.reg.Top()-1))
+	L.Push(LString(sb.String()))
 	return 1
 }
 


### PR DESCRIPTION
# Fix: Stack Overflow in table.concat Function

This PR fixes a stack overflow issue in the `table.concat` function when working with large tables.

## Problem
The previous implementation of `tableConcat` pushed all values and separators onto the Lua stack before concatenating them. This approach caused stack overflow errors when dealing with large tables.

## Solution
This fix changes the implementation to build the result string incrementally rather than pushing all values onto the stack first. Instead of accumulating items on the stack, we now:
- Build the string directly by appending each value 
- Add separators between values as needed
- Push only the final result string to the stack

## Testing
The fix has been verified with large tables that previously caused stack overflow. For example, this test case now works correctly:

```go
package main

import "github.com/yuin/gopher-lua"

func main() {
        var L *lua.LState
        var err error

        L = lua.NewState()
        defer L.Close()

        err = L.DoString(`
                local t = {}
                for i = 1, 10000 do
                        t[i] = tostring(i)
                end
                local s = table.concat(t, ',')
        `)
        if err != nil {
                println(err.Error())
        }
}
```

This example would previously fail with a stack overflow error but now executes successfully.