### PR TITLE
Issue #514 : Fix compileRegAssignment cardinality

### DIFF
--- a/_glua-tests/issues.lua
+++ b/_glua-tests/issues.lua
@@ -490,3 +490,22 @@ function test()
   assert(b == nil)
 end
 test()
+
+-- issue #514
+function test()
+  local tbl = {foo = 42, bar = "baz"}
+  local iter = function(s,k)
+    k,_ = next(tbl, k)
+    return k
+  end
+  local seen1, seen2 = {}, {}
+  for item in iter do
+    seen1[item] = true
+  end
+  for item in iter do
+    seen2[item] = true
+  end
+  assert(seen1.foo and seen1.bar)
+  assert(seen2.foo and seen2.bar)
+end
+test()

--- a/compile.go
+++ b/compile.go
@@ -812,20 +812,19 @@ func compileAssignStmt(context *funcContext, stmt *ast.AssignStmt) { // {{{
 	}
 } // }}}
 
-func compileRegAssignment(context *funcContext, names []string, exprs []ast.Expr, reg int, nvars int, line int) { // {{{
-	lennames := len(names)
+func compileRegAssignment(context *funcContext, exprs []ast.Expr, reg int, nvars int, line int) { // {{{
 	lenexprs := len(exprs)
 	namesassigned := 0
 	ec := &expcontext{}
 
-	for namesassigned < lennames && namesassigned < lenexprs {
+	for namesassigned < nvars && namesassigned < lenexprs {
 		if isVarArgReturnExpr(exprs[namesassigned]) && (lenexprs-namesassigned-1) <= 0 {
 
 			varargopt := nvars - namesassigned
 			ecupdate(ec, ecVararg, reg, varargopt-1)
 			compileExpr(context, reg, exprs[namesassigned], ec)
 			reg += varargopt
-			namesassigned = lennames
+			namesassigned = nvars
 		} else {
 			ecupdate(ec, ecLocal, reg, 0)
 			compileExpr(context, reg, exprs[namesassigned], ec)
@@ -835,8 +834,8 @@ func compileRegAssignment(context *funcContext, names []string, exprs []ast.Expr
 	}
 
 	// extra left names
-	if lennames > namesassigned {
-		restleft := lennames - namesassigned - 1
+	if nvars > namesassigned {
+		restleft := nvars - namesassigned - 1
 		context.Code.AddLoadNil(reg, reg+restleft, line)
 		reg += restleft
 	}
@@ -857,12 +856,12 @@ func compileLocalAssignStmt(context *funcContext, stmt *ast.LocalAssignStmt) { /
 	if len(stmt.Names) == 1 && len(stmt.Exprs) == 1 {
 		if _, ok := stmt.Exprs[0].(*ast.FunctionExpr); ok {
 			context.RegisterLocalVar(stmt.Names[0])
-			compileRegAssignment(context, stmt.Names, stmt.Exprs, reg, len(stmt.Names), sline(stmt))
+			compileRegAssignment(context, stmt.Exprs, reg, len(stmt.Names), sline(stmt))
 			return
 		}
 	}
 
-	compileRegAssignment(context, stmt.Names, stmt.Exprs, reg, len(stmt.Names), sline(stmt))
+	compileRegAssignment(context, stmt.Exprs, reg, len(stmt.Names), sline(stmt))
 	for _, name := range stmt.Names {
 		context.RegisterLocalVar(name)
 	}
@@ -1100,7 +1099,7 @@ func compileGenericForStmt(context *funcContext, stmt *ast.GenericForStmt) { // 
 	context.RegisterLocalVar("(for state)")
 	context.RegisterLocalVar("(for control)")
 
-	compileRegAssignment(context, stmt.Names, stmt.Exprs, context.RegTop()-3, 3, sline(stmt))
+	compileRegAssignment(context, stmt.Exprs, context.RegTop()-3, 3, sline(stmt))
 
 	code.AddASbx(OP_JMP, 0, fllabel, sline(stmt))
 


### PR DESCRIPTION
Fixes #514

Changes proposed in this pull request:

- In `compileRegAssignment`, use `nvars` as the assignment cardinality rather than `lennames`.
- Remove no-longer-used `names` argument

I don't really know what I'm doing, I just tried to infer what things were supposed to be doing based on their names. I started with the test case filed in #514 and compared with the behavior of official Lua 5.1. It turned out that `luac` has extra `LOADNIL` which reset the registers that weren't correctly reset by gopher-lua, so I poked around `compileGenericForStmt` and it took me a while to understand why the iteration variable names were fed to `compileRegAssignment` when its place in the code and the other arguments suggested it should be about initializing internal generator/state/control triplet rather than iteration variables.

I checked that after this change, the opcodes generated by gopher-lua are similar to those from luac, and the whole test suite passes.