### PR TITLE
fix os.date formatting with %x

### DIFF
--- a/oslib_test.go
+++ b/oslib_test.go
@@ -31,3 +31,16 @@ func TestOsWrite(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestOsDateFmt(t *testing.T) {
+	s := "return os.date('!weekday=%w|%a|%A, month=%b|%B, year=%y, time=%I:%M|%H:%M:%S|%X, date=%Y-%m-%d|%x', 1136214245)"
+	L := NewState()
+	defer L.Close()
+	if err := L.DoString(s); err != nil {
+		t.Error(err)
+	} else {
+		ret := L.Get(-1)
+		expected := LString("weekday=1|mon|Monday, month=Jan|January, year=06, time=03:04|15:04:05|15:04:05, date=2006-01-02|01/02/06")
+		errorIfNotEqual(t, expected, ret)
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -102,7 +102,7 @@ func (fs *flagScanner) Next() (byte, bool) {
 var cDateFlagToGo = map[byte]string{
 	'a': "mon", 'A': "Monday", 'b': "Jan", 'B': "January", 'c': "02 Jan 06 15:04 MST", 'd': "02",
 	'F': "2006-01-02", 'H': "15", 'I': "03", 'm': "01", 'M': "04", 'p': "PM", 'P': "pm", 'S': "05",
-	'x': "15/04/05", 'X': "15:04:05", 'y': "06", 'Y': "2006", 'z': "-0700", 'Z': "MST"}
+	'x': "01/02/06", 'X': "15:04:05", 'y': "06", 'Y': "2006", 'z': "-0700", 'Z': "MST"}
 
 func strftime(t time.Time, cfmt string) string {
 	sc := newFlagScanner('%', "", "", cfmt)


### PR DESCRIPTION
Changes proposed in this pull request:

- change format code `%x` to mean `%m/%d/%y` to match Lua (https://www.lua.org/pil/22.1.html) (before this PR it was `%H/%M/%S` I assume by mistake)
- add a test for date formatting

While writing the test I also noticed a few other date formatting codes that don't exactly match what Lua does:
- `%p` is "PM" ("pm" in Lua)
- `%c` is "02 Jan 06 15:04 MST" ("Mon Jan  2 15:04:05 2006" in Lua)

I decided to not include them in the test. I also left formatting codes that are not documented on lua.org untested.

The issue was first reported in micro: https://github.com/micro-editor/micro/issues/4067